### PR TITLE
fix(auth): truncate sessionValidAfter to seconds in revocation check

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -57,10 +57,14 @@ export const auth = (async (...args: any[]) => {
 
   const sessionIssuedAtMs = session.user.sessionIssuedAtMs;
 
+  // Compare in whole seconds — JWT iat is integer seconds (rounded down),
+  // so a freshly-issued token would otherwise be ~hundreds of ms before the
+  // ms-precise sessionValidAfter set at user-creation time and get rejected
+  // immediately on the very first authenticated request.
   if (
     user?.sessionValidAfter &&
     typeof sessionIssuedAtMs === "number" &&
-    sessionIssuedAtMs < user.sessionValidAfter.getTime()
+    sessionIssuedAtMs < Math.floor(user.sessionValidAfter.getTime() / 1000) * 1000
   ) {
     return null;
   }

--- a/src/lib/auth/mobileAuth.ts
+++ b/src/lib/auth/mobileAuth.ts
@@ -49,6 +49,11 @@ export async function mobileAuth(req: Request): Promise<Session | null> {
 
   // Apply revocation check — if the DB is unavailable, allow the session
   // rather than locking out all mobile users during a transient outage.
+  // JWT `iat` is integer seconds, so a token issued at the same instant a
+  // user is created (sessionValidAfter @default(now()), ms-precise) appears
+  // ~hundreds of ms before sessionValidAfter once iat is rounded down.
+  // Compare in whole seconds so a brand-new account is never rejected by
+  // its own freshly-issued token.
   try {
     const user = await db.user.findUnique({
       where: { id: userId },
@@ -58,7 +63,8 @@ export async function mobileAuth(req: Request): Promise<Session | null> {
     if (
       user?.sessionValidAfter &&
       sessionIssuedAtMs !== null &&
-      sessionIssuedAtMs < user.sessionValidAfter.getTime()
+      sessionIssuedAtMs <
+        Math.floor(user.sessionValidAfter.getTime() / 1000) * 1000
     ) {
       return null // Token has been revoked via POST /api/auth/revoke-session
     }


### PR DESCRIPTION
## Summary
- New accounts get `sessionValidAfter @default(now())` with ms precision; the JWT they receive seconds later has `iat` rounded to whole seconds. The revocation check `iat * 1000 < sessionValidAfter.getTime()` then trips on the freshly-issued token, so every first authenticated call (`GET /api/users/me`, `POST /api/users/username`, ...) returned 401 `{error:"Unauthorized"}` until enough seconds elapsed.
- Truncate `sessionValidAfter` to whole-second precision before comparing in both `mobileAuth.ts` (iOS Bearer) and `auth.ts` (web cookie).
- Genuine revocation still works: when `POST /api/auth/revoke-session` updates `validAfter` to now, any token with `iat` seconds *before* that is still rejected.

Closes #10

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (no warnings or errors)
- [x] `npm run build` succeeded (28/28 routes)
- [ ] After deploy: a brand-new Apple Sign-In on iOS lands inside the app (no red "Unauthorized")
- [ ] After deploy: existing user sessions still authenticate
- [ ] After deploy: `POST /api/auth/revoke-session` still invalidates older tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)