### PR TITLE
fix(ios): signInWithApple falls back to exchange data when /me fails

### DIFF
--- a/ios/FXRacing/Core/Auth/AuthManager.swift
+++ b/ios/FXRacing/Core/Auth/AuthManager.swift
@@ -63,7 +63,31 @@ final class AuthManager {
         try KeychainService.saveToken(exchange.accessToken)
         fxLog(.auth, "signInWithApple: token issued, userId=\(exchange.userId) usernameSet=\(exchange.usernameSet)")
 
-        let user: User = try await api.request(.me, token: exchange.accessToken)
+        // Sign-in succeeds the moment the exchange returns — the token is
+        // valid and saved. Try to enrich with /me, but if that call fails
+        // (e.g. transient 401 from a stale revocation snapshot, brief
+        // network blip), fall back to a User constructed from the exchange
+        // response. This guarantees the user always lands inside the app
+        // after a successful Apple authorization, instead of seeing the
+        // sign-in sheet error out post-authorization.
+        let user: User
+        do {
+            user = try await api.request(.me, token: exchange.accessToken)
+        } catch {
+            fxWarn(.auth, "signInWithApple: /me failed (\(error.localizedDescription)) — proceeding with exchange response")
+            user = User(
+                id: exchange.userId,
+                name: nil,
+                email: nil,
+                avatarUrl: nil,
+                publicUsername: exchange.publicUsername,
+                usernameSet: exchange.usernameSet,
+                usernameChangeUsed: false,
+                favoriteTeamSlug: nil,
+                tutorialDismissedAt: nil,
+                createdAt: Date()
+            )
+        }
         state = .authenticated(user)
         fxLog(.auth, "signInWithApple: state=authenticated user=\(user.id)")
 


### PR DESCRIPTION
## Summary
- A successful Apple authorization should always land the user inside the app. Today, any failure of `GET /api/users/me` after `POST /api/auth/mobile/exchange` is treated as a sign-in failure even though the token is already in Keychain.
- On `/me` error, log a warning and construct a `User` from the exchange response (`userId`, `usernameSet`, `publicUsername` are enough for `RootView` to route to `MainTabView` or `UsernamePickerView`).
- Belt-and-suspenders alongside the server fix in [#10](https://github.com/gibouu/f10_fantasy/issues/10) — protects the sign-in path against any future regression in auth-protected routes.

Closes #12

## Test plan
- [x] `xcodebuild -project FXRacing.xcodeproj -scheme FXRacing -destination 'generic/platform=iOS Simulator' build` BUILD SUCCEEDED
- [ ] Manual: stub `/me` to return 401 once → tap Sign in with Apple → user lands in `MainTabView` (or `UsernamePickerView` if `usernameSet=false`), no error sheet
- [ ] Manual: normal happy path still uses the full `/me` profile (favorite team, tutorial state, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)