### PR TITLE
ui: append 'S' to sprint round labels on web (closes #29)

### DIFF
--- a/src/app/(main)/profile/[userId]/page.tsx
+++ b/src/app/(main)/profile/[userId]/page.tsx
@@ -217,6 +217,7 @@ function PickRow({
         <div className="min-w-0">
           <p className="text-xs font-bold uppercase tracking-widest text-text-tertiary">
             R{pick.race.round}
+            {pick.race.type === 'SPRINT' ? 'S' : ''}
           </p>
           <p className="truncate text-sm font-semibold text-text-primary">{pick.race.name}</p>
         </div>

--- a/src/app/(main)/races/RacesListClient.tsx
+++ b/src/app/(main)/races/RacesListClient.tsx
@@ -70,7 +70,10 @@ function RaceCard({ race, picked, locked }: RaceCardProps) {
         className="flex items-center gap-4 bg-surface rounded-2xl px-4 py-3.5 border border-[var(--border)] active:opacity-70 transition-opacity"
       >
         <div className="w-8 shrink-0 text-center">
-          <span className="text-xs font-bold text-text-tertiary">R{race.round}</span>
+          <span className="text-xs font-bold text-text-tertiary">
+            R{race.round}
+            {race.type === "SPRINT" ? "S" : ""}
+          </span>
         </div>
 
         <div className="flex-1 min-w-0">

--- a/src/components/leaderboard/LeaderboardList.tsx
+++ b/src/components/leaderboard/LeaderboardList.tsx
@@ -142,7 +142,8 @@ function SortDropdown({
         <option value="season">{seasonYear} Season (total)</option>
         {completedRaces.map((race) => (
           <option key={race.id} value={race.id}>
-            R{race.round} · {race.name}
+            R{race.round}
+            {race.type === "SPRINT" ? "S" : ""} · {race.name}
           </option>
         ))}
       </select>


### PR DESCRIPTION
## Summary

After PR #28 renumbered to F1's official 1-22, sprint weekends have both a SPRINT and a MAIN row sharing the same round (e.g. \`R5\` Canadian Sprint + \`R5\` Canadian Grand Prix). Both cards rendered \`R5\` — visually duplicated.

Closes #29.

## Changes

3 compact-badge sites now append \`S\` for sprint rows:

- \`src/app/(main)/races/RacesListClient.tsx\` — race list card
- \`src/components/leaderboard/LeaderboardList.tsx\` — race selector dropdown
- \`src/app/(main)/profile/[userId]/page.tsx\` — pick history row

Two other surfaces (\`HeroVisualization.tsx\`, \`PickHero.tsx\`) already render \"Sprint\" as a word/badge next to \"Round N\" and are intentionally left alone.

## iOS: out of scope

The iOS race card already shows a bold \"⚡ Sprint\" badge (visible in user's screenshot), so it has clear visual distinction even without the \`S\` suffix. Adding the suffix to iOS would require a Swift change + App Store update, and the user prefers to defer iOS resubmissions.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean
- [x] \`npm run build\` clean
- [ ] After deploy + prod renumber: confirm \`R5S Canadian Sprint\` / \`R5 Canadian Grand Prix\` on /races

— Claude + gib