### PR TITLE
Fix encrypted token parser

### DIFF
--- a/src/lib/security/account-token-crypto.ts
+++ b/src/lib/security/account-token-crypto.ts
@@ -55,8 +55,15 @@ export function decryptTokenValue(value: string): string {
     return value;
   }
 
-  const [, ivRaw, authTagRaw, encryptedRaw] = value.split(":");
-  if (!ivRaw || !authTagRaw || !encryptedRaw) {
+  const [prefix, version, ivRaw, authTagRaw, encryptedRaw, ...extra] =
+    value.split(":");
+  if (
+    `${prefix}:${version}` !== ENCRYPTED_TOKEN_PREFIX ||
+    !ivRaw ||
+    !authTagRaw ||
+    !encryptedRaw ||
+    extra.length > 0
+  ) {
     console.warn("[token-crypto] Malformed ciphertext, returning raw value");
     return value;
   }


### PR DESCRIPTION
Closes #35

## Summary
- Parse encrypted OAuth token payloads as `enc:v1:<iv>:<authTag>:<ciphertext>`.
- Reject malformed payload shapes before attempting AES-GCM decryption.

## Test Plan
- [x] `ACCOUNT_TOKEN_ENCRYPTION_KEY=test node -e 'const jiti = require("jiti")(process.cwd() + "/"); const { encryptTokenValue, decryptTokenValue } = jiti("./src/lib/security/account-token-crypto.ts"); const encrypted = encryptTokenValue("abc"); const decrypted = decryptTokenValue(encrypted); if (decrypted !== "abc") process.exit(1); const malformed = "enc:v1:only-iv"; if (decryptTokenValue(malformed) !== malformed) process.exit(1);'`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`