### PR TITLE
Require verified mobile OAuth emails for account linking

### DIFF
--- a/src/app/api/auth/mobile/exchange/route.ts
+++ b/src/app/api/auth/mobile/exchange/route.ts
@@ -27,6 +27,7 @@ import { NextResponse } from 'next/server'
 import { createRemoteJWKSet, jwtVerify, SignJWT } from 'jose'
 import { db } from '@/lib/db/client'
 import { mobileSigningKey } from '@/lib/auth/mobileAuth'
+import { verifiedProviderEmail } from '@/lib/auth/providerEmail'
 
 // 60 days. Native iOS users expect to stay signed in across launches; the 8h
 // expiry forced re-sign-in every day. Server-side revocation is still
@@ -70,7 +71,7 @@ async function verifyAppleToken(idToken: string): Promise<ProviderClaims | null>
       return {
         sub: payload.sub as string,
         email: (payload.email as string) ?? '',
-        email_verified: payload.email_verified as boolean | undefined,
+        email_verified: payload.email_verified as boolean | string | undefined,
         name: (payload.name as string) ?? undefined,
       }
     } catch {
@@ -97,7 +98,7 @@ async function verifyGoogleToken(idToken: string): Promise<ProviderClaims | null
       return {
         sub: payload.sub as string,
         email: (payload.email as string) ?? '',
-        email_verified: payload.email_verified as boolean | undefined,
+        email_verified: payload.email_verified as boolean | string | undefined,
         name: (payload.name as string) ?? undefined,
         picture: (payload.picture as string) ?? undefined,
       }
@@ -144,8 +145,8 @@ async function findOrCreateUser(
     return existingAccount.user
   }
 
-  // 2. No Account found — check if a User with this email already exists
-  const email = claims.email
+  // 2. No Account found — check if a User with this verified email already exists
+  const email = verifiedProviderEmail(claims)
   const existingUser = email
     ? await db.user.findUnique({
         where: { email },
@@ -179,7 +180,7 @@ async function findOrCreateUser(
       email: email || `${provider}.${providerAccountId}@placeholder.fxracing`,
       name: claims.name ?? null,
       image: claims.picture ?? null,
-      emailVerified: claims.email_verified ? new Date() : null,
+      emailVerified: email ? new Date() : null,
       accounts: {
         create: {
           type: 'oauth',

--- a/src/lib/auth/providerEmail.ts
+++ b/src/lib/auth/providerEmail.ts
@@ -1,0 +1,12 @@
+type ProviderEmailClaims = {
+  email: string
+  email_verified?: boolean | string
+}
+
+export function isVerifiedProviderEmail(value: boolean | string | undefined): boolean {
+  return value === true || value === "true"
+}
+
+export function verifiedProviderEmail(claims: ProviderEmailClaims): string {
+  return isVerifiedProviderEmail(claims.email_verified) ? claims.email : ""
+}


### PR DESCRIPTION
Closes #39

## Summary
- Normalize provider email verification values before using email claims.
- Only look up and link existing users by verified provider email.
- Create placeholder-email mobile accounts when the provider email is unverified.

## Test Plan
- [x] `npx tsx -e 'import { isVerifiedProviderEmail, verifiedProviderEmail } from "./src/lib/auth/providerEmail"; if (isVerifiedProviderEmail(false) !== false) process.exit(2); if (isVerifiedProviderEmail("false") !== false) process.exit(3); if (isVerifiedProviderEmail(true) !== true) process.exit(4); if (isVerifiedProviderEmail("true") !== true) process.exit(5); if (verifiedProviderEmail({ email: "victim@example.com", email_verified: false }) !== "") process.exit(6); if (verifiedProviderEmail({ email: "victim@example.com", email_verified: "false" }) !== "") process.exit(7); if (verifiedProviderEmail({ email: "victim@example.com", email_verified: true }) !== "victim@example.com") process.exit(8);'`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`