### PR TITLE
Narrow API bearer middleware bypass

### DIFF
--- a/src/lib/auth/bearerRoute.ts
+++ b/src/lib/auth/bearerRoute.ts
@@ -1,0 +1,24 @@
+const MOBILE_BEARER_API_PATHS = new Set([
+  "/api/account",
+  "/api/friends",
+  "/api/leaderboard",
+  "/api/picks",
+  "/api/users/me",
+  "/api/users/team",
+  "/api/users/tutorial",
+  "/api/users/username",
+])
+
+const MOBILE_BEARER_API_PREFIXES = ["/api/friends/"]
+
+const SECRET_BEARER_API_PATHS = new Set(["/api/diag/health"])
+const SECRET_BEARER_API_PREFIXES = ["/api/diag/race/"]
+
+export function isBearerAuthApiRoute(pathname: string, _method: string): boolean {
+  return (
+    MOBILE_BEARER_API_PATHS.has(pathname) ||
+    MOBILE_BEARER_API_PREFIXES.some((prefix) => pathname.startsWith(prefix)) ||
+    SECRET_BEARER_API_PATHS.has(pathname) ||
+    SECRET_BEARER_API_PREFIXES.some((prefix) => pathname.startsWith(prefix))
+  )
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,6 +3,7 @@ import type { NextRequest } from "next/server";
 import NextAuth from "next-auth";
 import { authConfig } from "@/auth.config";
 import type { Session } from "next-auth";
+import { isBearerAuthApiRoute } from "@/lib/auth/bearerRoute";
 
 const { auth } = NextAuth(authConfig);
 
@@ -88,10 +89,11 @@ export default auth((req: NextAuthRequest) => {
 
   // ── 4. Unauthenticated users → redirect to /signin ────────────────────
   if (!session) {
-    // API requests that carry a Bearer token are authenticated in the route
-    // handler itself via mobileAuth(req). Let them through without redirect.
+    // Only explicit Bearer-capable API routes bypass the web-session redirect.
+    // Those handlers must validate either mobileAuth(req) or CRON_SECRET.
     if (
       pathname.startsWith(API_PREFIX) &&
+      isBearerAuthApiRoute(pathname, req.method) &&
       req.headers.get("authorization")?.startsWith("Bearer ")
     ) {
       return NextResponse.next();


### PR DESCRIPTION
Closes #47

## Summary
- Replace the global `/api` Bearer-header middleware bypass with an explicit Bearer-capable route allowlist.
- Keep mobile-token API routes and CRON_SECRET diagnostic routes passing through to their route-level validators.
- Document the route-level validation contract in middleware.

## Test Plan
- [x] `npx tsx -e 'import { isBearerAuthApiRoute } from "./src/lib/auth/bearerRoute"; if (isBearerAuthApiRoute("/api/picks", "POST") !== true) process.exit(2); if (isBearerAuthApiRoute("/api/leaderboard", "GET") !== true) process.exit(3); if (isBearerAuthApiRoute("/api/diag/health", "GET") !== true) process.exit(4); if (isBearerAuthApiRoute("/api/cron/sync-schedule", "POST") !== false) process.exit(5); if (isBearerAuthApiRoute("/api/protected-new", "GET") !== false) process.exit(6);'`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`