### PR TITLE
Require results when auto-resolving score race

### DIFF
--- a/src/app/api/cron/compute-scores/route.ts
+++ b/src/app/api/cron/compute-scores/route.ts
@@ -9,6 +9,11 @@ import type { NextRequest } from "next/server"
 import { db } from "@/lib/db/client"
 import { computeAndStoreScoresForRace } from "@/lib/services/scoring.service"
 
+const SCORABLE_COMPLETED_RACE_WHERE = {
+  status: "COMPLETED" as const,
+  results: { some: {} },
+}
+
 // ─── Auth helper ──────────────────────────────────────────────────────────────
 
 function validateCronSecret(req: NextRequest): boolean {
@@ -52,9 +57,8 @@ export async function POST(req: NextRequest) {
   if (raceType) {
     const races = await db.race.findMany({
       where: {
+        ...SCORABLE_COMPLETED_RACE_WHERE,
         type: raceType,
-        status: "COMPLETED",
-        results: { some: {} },
       },
       orderBy: { scheduledStartUtc: "asc" },
       select: { id: true },
@@ -82,15 +86,15 @@ export async function POST(req: NextRequest) {
 
   if (!raceId) {
     const lastCompleted = await db.race.findFirst({
-      where: { status: "COMPLETED" },
+      where: SCORABLE_COMPLETED_RACE_WHERE,
       orderBy: { scheduledStartUtc: "desc" },
       select: { id: true, name: true },
     })
 
     if (!lastCompleted) {
-      console.warn("[f10:cron:scores] no completed races to score")
+      console.warn("[f10:cron:scores] no completed races with results to score")
       return NextResponse.json(
-        { error: "No completed races found to score" },
+        { error: "No completed races with results found to score" },
         { status: 404 },
       )
     }


### PR DESCRIPTION
Closes #49

## Summary
- Share the completed-with-results predicate between batch scoring and default auto-resolve.
- Return a clear no-scorable-races 404 when no completed race has results.
- Avoid invoking scoring for completed races that cannot be scored yet.

## Test Plan
- [x] `rg -n 'where: \\{ status: "COMPLETED" \\}|No completed races found to score|SCORABLE_COMPLETED_RACE_WHERE' src/app/api/cron/compute-scores/route.ts`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`