### PR TITLE
Return failure status for batch score errors

### DIFF
--- a/src/app/api/cron/compute-scores/route.ts
+++ b/src/app/api/cron/compute-scores/route.ts
@@ -81,7 +81,16 @@ export async function POST(req: NextRequest) {
     }
 
     console.log(`[f10:cron:scores] done in ${Date.now() - startedAt}ms`)
-    return NextResponse.json({ raceType, processed: results })
+    const failedCount = results.filter((result) => result.error).length
+    return NextResponse.json(
+      {
+        raceType,
+        processedCount: results.length,
+        failedCount,
+        processed: results,
+      },
+      { status: failedCount > 0 ? 500 : 200 },
+    )
   }
 
   if (!raceId) {


### PR DESCRIPTION
Closes #51

## Summary
- Add top-level `processedCount` and `failedCount` to raceType batch scoring responses.
- Return HTTP 500 when any per-race scoring item fails.
- Preserve per-race error details in `processed`.

## Test Plan
- [x] `rg -n 'failedCount|processedCount|status: failedCount > 0 \\? 500 : 200' src/app/api/cron/compute-scores/route.ts`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`