### PR TITLE
Migrate legacy local pick storage key

### DIFF
--- a/ios/CLAUDE.md
+++ b/ios/CLAUDE.md
@@ -113,7 +113,7 @@ Sign-in trigger:
 
 ## Local persistence
 
-### LocalPickStore (`UserDefaults` key: `"localPicks"`)
+### LocalPickStore (`UserDefaults` key: `"localPicks_v1"`)
 ```swift
 struct LocalPick: Codable {
   raceId, winnerId, p10Id, dnfId: String
@@ -122,6 +122,7 @@ struct LocalPick: Codable {
 }
 // Stored as [raceId: LocalPick] JSON
 ```
+- On first launch after upgrade, reads legacy `"localPicks"` if `"localPicks_v1"` is absent, persists under `"localPicks_v1"`, then removes the legacy key
 - Survives app backgrounding and device restart
 - Does NOT survive reinstall (acceptable)
 - Does NOT require auth

--- a/ios/FXRacing/Core/Storage/LocalPickStore.swift
+++ b/ios/FXRacing/Core/Storage/LocalPickStore.swift
@@ -17,6 +17,7 @@ struct LocalPick: Codable, Sendable {
 final class LocalPickStore {
 
     private static let key = "localPicks_v1"
+    private static let legacyKey = "localPicks"
     private(set) var picks: [String: LocalPick] = [:]
 
     init() {
@@ -59,10 +60,19 @@ final class LocalPickStore {
     // MARK: - Persistence
 
     private func load() {
-        guard let data = UserDefaults.standard.data(forKey: Self.key),
-              let decoded = try? JSONDecoder().decode([String: LocalPick].self, from: data)
+        if let data = UserDefaults.standard.data(forKey: Self.key),
+           let decoded = try? JSONDecoder().decode([String: LocalPick].self, from: data) {
+            picks = decoded
+            return
+        }
+
+        guard let legacyData = UserDefaults.standard.data(forKey: Self.legacyKey),
+              let legacyPicks = try? JSONDecoder().decode([String: LocalPick].self, from: legacyData)
         else { return }
-        picks = decoded
+
+        picks = legacyPicks
+        persist()
+        UserDefaults.standard.removeObject(forKey: Self.legacyKey)
     }
 
     private func persist() {


### PR DESCRIPTION
Closes #53

## Summary
- Add a one-time fallback read from the legacy `localPicks` UserDefaults key when `localPicks_v1` is absent.
- Persist successfully decoded legacy picks under `localPicks_v1` and remove the legacy key.
- Update iOS engineering memory to document the current key and migration path.

## Test Plan
- [x] `xcodebuild -project FXRacing.xcodeproj -scheme FXRacing -destination 'generic/platform=iOS Simulator' build`