### PR TITLE
Stop trusting generic forwarded IP header

### DIFF
--- a/src/lib/security/rate-limit.ts
+++ b/src/lib/security/rate-limit.ts
@@ -21,6 +21,7 @@ declare global {
 }
 
 const buckets = globalThis.__rateLimitBuckets ?? new Map<string, Bucket>()
+const TRUSTED_CLIENT_IP_HEADERS = ["x-vercel-forwarded-for", "cf-connecting-ip"]
 
 if (!globalThis.__rateLimitBuckets) {
   globalThis.__rateLimitBuckets = buckets
@@ -75,14 +76,12 @@ export function rateLimit({
 }
 
 export function getClientIp(request: Request): string {
-  const forwardedFor = request.headers.get("x-forwarded-for")
-  if (forwardedFor) {
-    return forwardedFor.split(",")[0]?.trim() || "unknown"
+  for (const header of TRUSTED_CLIENT_IP_HEADERS) {
+    const value = request.headers.get(header)?.split(",")[0]?.trim()
+    if (value) {
+      return value
+    }
   }
 
-  return (
-    request.headers.get("x-real-ip") ??
-    request.headers.get("cf-connecting-ip") ??
-    "unknown"
-  )
+  return "unknown"
 }


### PR DESCRIPTION
Closes #55

## Summary
- Stop using arbitrary `X-Forwarded-For` and `X-Real-IP` values for rate-limit identity.
- Use a small trusted-header list, preferring Vercel's forwarded IP header and Cloudflare's connecting IP header.
- Fall back to `unknown` when no trusted platform header is present.

## Test Plan
- [x] `npx tsx -e 'import { getClientIp } from "./src/lib/security/rate-limit"; const spoofed = new Request("https://example.test", { headers: { "x-forwarded-for": "1.2.3.4" } }); if (getClientIp(spoofed) !== "unknown") process.exit(2); const trusted = new Request("https://example.test", { headers: { "x-vercel-forwarded-for": "5.6.7.8, 9.9.9.9", "x-forwarded-for": "1.2.3.4" } }); if (getClientIp(trusted) !== "5.6.7.8") process.exit(3);'`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`