### PR TITLE
Refresh session claims from trusted user row

### DIFF
--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -20,20 +20,11 @@ export const authConfig: NextAuthConfig = {
   providers: [],
 
   callbacks: {
-    jwt({ token, user, trigger, session }) {
+    jwt({ token, user }) {
       if (user) {
         token.id = user.id;
         token.publicUsername = (user as { publicUsername?: string | null }).publicUsername ?? null;
         token.usernameSet = (user as { usernameSet?: boolean }).usernameSet ?? false;
-      }
-
-      if (trigger === "update" && session) {
-        if (typeof session.publicUsername === "string") {
-          token.publicUsername = session.publicUsername;
-        }
-        if (typeof session.usernameSet === "boolean") {
-          token.usernameSet = session.usernameSet;
-        }
       }
 
       return token;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -33,6 +33,25 @@ const nextAuth = NextAuth({
   callbacks: {
     ...authConfig.callbacks,
 
+    async jwt({ token, user, trigger }) {
+      if (user) {
+        token.id = user.id;
+        token.publicUsername = user.publicUsername ?? null;
+        token.usernameSet = user.usernameSet ?? false;
+      }
+
+      if (trigger === "update" && typeof token.id === "string") {
+        const currentUser = await db.user.findUnique({
+          where: { id: token.id },
+          select: { publicUsername: true, usernameSet: true },
+        });
+        token.publicUsername = currentUser?.publicUsername ?? null;
+        token.usernameSet = currentUser?.usernameSet ?? false;
+      }
+
+      return token;
+    },
+
     async signIn({ user }) {
       return Boolean(user.email ?? user.id);
     },


### PR DESCRIPTION
Closes #57

## Summary
- Remove client-provided session payload writes from the shared edge-safe JWT callback.
- Refresh `publicUsername` and `usernameSet` on update only from the database-backed Node Auth.js config.
- Preserve post-username-update session refresh behavior without trusting forged client fields.

## Test Plan
- [x] `rg -n 'trigger === "update" && session|session\.publicUsername|session\.usernameSet' src/auth.config.ts src/auth.ts` returns no matches
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`