### PR TITLE
Skip completed race schedule updates

### DIFF
--- a/src/app/api/cron/sync-schedule/route.ts
+++ b/src/app/api/cron/sync-schedule/route.ts
@@ -237,7 +237,7 @@ export async function POST(req: NextRequest) {
           openf1MeetingKey: session.meetingKey,
           type: raceType as "MAIN" | "SPRINT",
         },
-        select: { id: true },
+        select: { id: true, status: true },
       })
 
       if (!existing) {
@@ -252,17 +252,19 @@ export async function POST(req: NextRequest) {
               lte: new Date(start + windowMs),
             },
           },
-          select: { id: true },
+          select: { id: true, status: true },
         })
       }
 
       let raceId: string
       if (existing) {
-        await db.race.update({
-          where: { id: existing.id },
-          data: { ...updatePayload, openf1SessionKey: session.sessionKey },
-        })
         raceId = existing.id
+        if (existing.status !== "COMPLETED") {
+          await db.race.update({
+            where: { id: existing.id },
+            data: { ...updatePayload, openf1SessionKey: session.sessionKey },
+          })
+        }
       } else {
         const created = await db.race.create({
           data: createPayload,


### PR DESCRIPTION
Closes #59

## Summary
- Fetch race status when matching existing schedule rows.
- Do not update matched `COMPLETED` races in sync-schedule.
- Still record completed race IDs as touched so reconciliation bookkeeping remains safe.

## Test Plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`