### PR TITLE
Add mobile exchange race guard check

### DIFF
--- a/scripts/test-mobile-exchange-race-guards.ts
+++ b/scripts/test-mobile-exchange-race-guards.ts
@@ -1,0 +1,28 @@
+/**
+ * Regression guard for mobile OAuth first-login race handling.
+ *
+ * This repo does not have a DB-backed test harness. This executable check
+ * protects the critical concurrency guardrails in the route implementation.
+ *
+ *   npx tsx scripts/test-mobile-exchange-race-guards.ts
+ */
+import { readFileSync } from "node:fs"
+
+const route = readFileSync("src/app/api/auth/mobile/exchange/route.ts", "utf8")
+
+const requiredSnippets = [
+  "Prisma.PrismaClientKnownRequestError",
+  "err.code === 'P2002'",
+  "db.account.upsert",
+  "const racedAccount = await db.account.findUnique",
+  "const racedUser = email",
+]
+
+for (const snippet of requiredSnippets) {
+  if (!route.includes(snippet)) {
+    console.error(`Missing mobile exchange race guard: ${snippet}`)
+    process.exit(1)
+  }
+}
+
+console.log("PASS mobile exchange race guards")


### PR DESCRIPTION
Closes #63

## Summary
- Add an executable regression guard for the mobile exchange unique-race protections.
- Check for the P2002 guard, account upsert, raced account re-read, and raced verified-email user re-read.

## Test Plan
- [x] `npx tsx scripts/test-mobile-exchange-race-guards.ts`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`