### PR TITLE
Make username change eligibility atomic

### DIFF
--- a/src/lib/services/user.service.ts
+++ b/src/lib/services/user.service.ts
@@ -169,10 +169,20 @@ export async function changeUsername(
       throw new Error(`Username "${username}" is already taken`)
     }
 
-    await tx.user.update({
-      where: { id: userId },
-      data: { publicUsername: stored, usernameChangeUsed: true },
+    const updated = await tx.user.updateMany({
+      where: {
+        id: userId,
+        usernameSet: true,
+        usernameChangeUsed: false,
+      },
+      data: {
+        publicUsername: stored,
+        usernameChangeUsed: true,
+      },
     })
+    if (updated.count !== 1) {
+      throw new Error('You have already used your one-time username change')
+    }
   })
 
   return stored


### PR DESCRIPTION
Closes #65

## Summary
- Keep existing username-change validation and availability checks.
- Replace the final unconditional user update with an atomic `updateMany` gated by `usernameSet: true` and `usernameChangeUsed: false`.
- Return the existing one-time-change error when a concurrent request loses the eligibility race.

## Test Plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`