### PR TITLE
Use local API for debug iOS builds

### DIFF
--- a/ios/FXRacing/Core/Config.swift
+++ b/ios/FXRacing/Core/Config.swift
@@ -2,11 +2,11 @@ import Foundation
 
 enum Config {
     #if DEBUG
+    static let apiBaseURL = URL(string: "http://127.0.0.1:3000")!
+    #else
     /// Use the canonical production host. Avoid the apex domain here:
     /// if it redirects to `www`, URLSession may drop the Authorization header
     /// on the redirected request and mobile Bearer auth will fail.
-    static let apiBaseURL = URL(string: "https://www.fxracing.ca")!
-    #else
     static let apiBaseURL = URL(string: "https://www.fxracing.ca")!
     #endif
 }


### PR DESCRIPTION
Closes #67

## Summary
- Point DEBUG iOS builds at `http://127.0.0.1:3000` for local backend development.
- Keep Release builds on the canonical production `https://www.fxracing.ca` host.

## Test Plan
- [x] `xcodebuild -project FXRacing.xcodeproj -scheme FXRacing -destination 'generic/platform=iOS Simulator' build`