### PR TITLE
Tolerate missing qualifying rows in entrants

### DIFF
--- a/src/lib/services/race.service.ts
+++ b/src/lib/services/race.service.ts
@@ -184,7 +184,9 @@ export async function getRaceEntrants(
   const [entries, resultRows, qualifyingRows] = await Promise.all([
     db.raceEntry.findMany({ where: { raceId }, select: { driverId: true } }),
     db.raceResult.findMany({ where: { raceId }, select: { driverId: true } }),
-    db.qualifyingResult.findMany({ where: { raceId }, select: { driverId: true } }),
+    db.qualifyingResult
+      .findMany({ where: { raceId }, select: { driverId: true } })
+      .catch(() => []),
   ])
 
   const driverIds = new Set<string>([


### PR DESCRIPTION
Closes #69

## Summary
- Make the qualifying-result portion of `getRaceEntrants` defensive.
- Preserve race-entry and race-result entrant sources if `qualifyingResult.findMany` fails during release ordering.

## Test Plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`