### PR TITLE
Declare jose as app dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^11.11.17",
+        "jose": "^6.2.2",
         "lucide-react": "^0.400.0",
         "next": "^14.2.35",
         "next-auth": "^5.0.0-beta.25",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^11.11.17",
+    "jose": "^6.2.2",
     "lucide-react": "^0.400.0",
     "next": "^14.2.35",
     "next-auth": "^5.0.0-beta.25",


### PR DESCRIPTION
Closes #71

## Summary
- Add `jose` as a direct runtime dependency because the mobile exchange route imports it directly.
- Update the root lockfile dependency metadata to match the already locked installed version.

## Test Plan
- [x] `npm ls jose --depth=0`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`