### PR TITLE
Support documented friend search parameter

### DIFF
--- a/src/app/api/friends/route.ts
+++ b/src/app/api/friends/route.ts
@@ -24,9 +24,9 @@ export async function GET(request: NextRequest) {
   const userId = session.user.id
 
   const { searchParams } = request.nextUrl
-  const searchQuery = searchParams.get('q')
+  const searchQuery = searchParams.get('search') ?? searchParams.get('q')
 
-  // Delegate to search if ?q= param is present
+  // Delegate to search if ?search= or legacy ?q= param is present
   if (searchQuery !== null) {
     const results = await searchUsers(searchQuery, userId)
     return NextResponse.json(results)


### PR DESCRIPTION
Closes #75

## Summary
- Make `GET /api/friends?search=<query>` invoke friend search as documented.
- Keep legacy `?q=<query>` support for existing callers.

## Test Plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`