### PR TITLE
Remove unused FriendSearch props

### DIFF
--- a/src/components/leaderboard/FriendSearch.tsx
+++ b/src/components/leaderboard/FriendSearch.tsx
@@ -9,7 +9,6 @@ import { cn } from '@/lib/utils'
 import { Avatar } from '@/components/ui/avatar'
 import { Button } from '@/components/ui/button'
 import type { FriendRequestData } from '@/types/domain'
-import { FriendRequestStatus } from '@/types/domain'
 
 // ─────────────────────────────────────────────
 // Types
@@ -27,10 +26,6 @@ type FriendsData = {
   friends: SearchResult[]
   pendingReceived: FriendRequestData[]
   pendingSent: FriendRequestData[]
-}
-
-interface FriendSearchProps {
-  currentUserId: string
 }
 
 // ─────────────────────────────────────────────
@@ -52,7 +47,7 @@ function useDebounce<T>(value: T, ms: number): T {
 // Main component
 // ─────────────────────────────────────────────
 
-export function FriendSearch({ currentUserId }: FriendSearchProps) {
+export function FriendSearch() {
   const [query, setQuery] = React.useState('')
   const debouncedQuery = useDebounce(query, 300)
 

--- a/src/components/leaderboard/LeaderboardList.tsx
+++ b/src/components/leaderboard/LeaderboardList.tsx
@@ -321,7 +321,7 @@ export function LeaderboardList({
 
       {/* Manage Friends — only on Friends tab */}
       {scope === 'friends' && userId && (
-        <FriendSearch currentUserId={userId} />
+        <FriendSearch />
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- remove the unused `FriendRequestStatus` value import from `FriendSearch`
- remove the unused `currentUserId` prop from `FriendSearch` and its only call site
- keep friend-search user exclusion in the authenticated API/service layer

Closes #81

## Test Plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`