### PR TITLE
Allow guest global leaderboard access

### DIFF
--- a/ios/FXRacing/Features/Rankings/LeaderboardView.swift
+++ b/ios/FXRacing/Features/Rankings/LeaderboardView.swift
@@ -12,7 +12,7 @@ struct LeaderboardView: View {
             if vm.isLoading && vm.rows.isEmpty {
                 leaderboardSkeleton
             } else if let err = vm.errorMessage, vm.rows.isEmpty {
-                RetryView(message: err) { await vm.load(token: authManager.accessToken) }
+                RetryView(message: err) { await loadIfAllowed() }
             } else {
                 list
             }
@@ -34,7 +34,7 @@ struct LeaderboardView: View {
             }
         }
         .sheet(isPresented: $showFriendSearch, onDismiss: {
-            Task { await vm.load(token: authManager.accessToken) }
+            Task { await loadIfAllowed() }
         }) {
             FriendSearchView()
         }
@@ -42,12 +42,10 @@ struct LeaderboardView: View {
             SignInPromptView(reason: "Sign in to add friends and see the Friends leaderboard.")
         }
         .task {
-            guard authManager.isAuthenticated else { return }
-            await vm.load(token: authManager.accessToken)
+            await loadIfAllowed()
         }
         .refreshable {
-            guard authManager.isAuthenticated else { return }
-            await vm.load(token: authManager.accessToken)
+            await loadIfAllowed()
         }
         .safeAreaInset(edge: .bottom) {
             if !tutorialStore.hasSeenLeaderboardTutorial && !authManager.isAuthenticated {
@@ -86,8 +84,7 @@ struct LeaderboardView: View {
                 // tap immediately — avoids a visible bounce-back while the
                 // async load runs.
                 vm.scope = newScope
-                guard authManager.isAuthenticated else { return }
-                Task { await vm.load(token: authManager.accessToken) }
+                Task { await loadIfAllowed() }
             }
         )) {
             ForEach(LeaderboardViewModel.Scope.allCases, id: \.self) {
@@ -101,15 +98,15 @@ struct LeaderboardView: View {
     @ViewBuilder
     private var list: some View {
         List {
-            if !authManager.isAuthenticated {
+            if vm.scope == .friends && !authManager.isAuthenticated {
                 Section {
                     VStack(spacing: 16) {
-                        Image(systemName: "trophy")
+                        Image(systemName: "person.2")
                             .font(.system(size: 40))
                             .foregroundStyle(FXTheme.Colors.accent)
-                        Text("Sign in to view your ranking")
+                        Text("Sign in to view friends")
                             .font(.headline)
-                        Text("Compete on the global and friends leaderboards by signing in.")
+                        Text("Global rankings are public. Sign in to add friends and compare private leaderboards.")
                             .font(.subheadline)
                             .foregroundStyle(.secondary)
                             .multilineTextAlignment(.center)
@@ -161,6 +158,11 @@ struct LeaderboardView: View {
     private var currentUserId: String? {
         if case .authenticated(let user) = authManager.state { return user.id }
         return nil
+    }
+
+    private func loadIfAllowed() async {
+        guard vm.scope == .global || authManager.isAuthenticated else { return }
+        await vm.load(token: authManager.accessToken)
     }
 
     private var leaderboardSkeleton: some View {

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -9,18 +9,18 @@ import {
 import { getActiveSeason } from '@/lib/services/race.service'
 
 export async function GET(request: NextRequest) {
-  // Auth check
-  const session = (await auth()) ?? (await mobileAuth(request))
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
-  const userId = session.user.id
-
   // Parse query params
   const { searchParams } = request.nextUrl
   const scope = searchParams.get('scope') === 'friends' ? 'friends' : 'global'
   // sort = 'season' (full season) or a specific raceId
   const sort = searchParams.get('sort') ?? 'season'
+
+  // Auth is required for Friends scope and optional for Global scope.
+  const session = (await auth()) ?? (await mobileAuth(request))
+  const userId = session?.user?.id ?? null
+  if (scope === 'friends' && !userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
 
   // Determine season — prefer explicit param, fall back to active season
   const seasonIdParam = searchParams.get('seasonId')
@@ -42,10 +42,10 @@ export async function GET(request: NextRequest) {
       : await getGlobalLeaderboard(seasonId, sort, 20)
 
   // User's own rank on the global season board (for pinned row logic)
-  const userRank = await getUserSeasonRank(userId, seasonId)
+  const userRank = userId ? await getUserSeasonRank(userId, seasonId) : null
 
   // Find the user's row in the returned set (may be null if they're outside top 20)
-  const userRow = rows.find((r) => r.userId === userId) ?? null
+  const userRow = userId ? (rows.find((r) => r.userId === userId) ?? null) : null
 
   return NextResponse.json({ rows, userRank, userRow })
 }


### PR DESCRIPTION
## Summary
- allow anonymous `/api/leaderboard?scope=global` requests while keeping Friends scope auth-gated
- return `userRank` / `userRow` only when a user is authenticated
- make the iOS Rankings view load Global scope for guests and show sign-in only on Friends scope

Closes #83

## Test Plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `xcodebuild -project FXRacing.xcodeproj -scheme FXRacing -destination 'generic/platform=iOS Simulator' build`