### PR TITLE
Hide token outside authenticated state

### DIFF
--- a/ios/FXRacing/Core/Auth/AuthManager.swift
+++ b/ios/FXRacing/Core/Auth/AuthManager.swift
@@ -150,7 +150,10 @@ final class AuthManager {
 
     // MARK: - Convenience
 
-    var accessToken: String? { KeychainService.loadToken() }
+    var accessToken: String? {
+        guard isAuthenticated else { return nil }
+        return KeychainService.loadToken()
+    }
 
     var isAuthenticated: Bool {
         if case .authenticated = state { return true }


### PR DESCRIPTION
## Summary
- make `AuthManager.accessToken` return nil unless the manager is currently authenticated
- keep private keychain reads unchanged for restore/sign-in/onboarding flows
- prevent guest-mode network calls from carrying a saved bearer token after transient restore failures

Closes #85

## Test Plan
- [x] `xcodebuild -project FXRacing.xcodeproj -scheme FXRacing -destination 'generic/platform=iOS Simulator' build`