### PR TITLE
Stop idle ingest fallback

### DIFF
--- a/src/app/api/cron/ingest-results/route.ts
+++ b/src/app/api/cron/ingest-results/route.ts
@@ -40,7 +40,7 @@ export async function POST(req: NextRequest) {
 
   const startedAt = Date.now()
   let targetRaceIds: string[]
-  let mode: 'force' | 'targeted' | 'auto' | 'fallback-latest' = 'auto'
+  let mode: 'force' | 'targeted' | 'auto' = 'auto'
 
   try {
     const body = await req.json()
@@ -68,18 +68,6 @@ export async function POST(req: NextRequest) {
       findRacesNeedingQualifyingIngestion(),
     ])
     targetRaceIds = Array.from(new Set([...needResults, ...needQuali]))
-  }
-
-  if (targetRaceIds.length === 0) {
-    const latest = await db.race.findFirst({
-      where: { status: 'COMPLETED', openf1SessionKey: { not: null } },
-      orderBy: { scheduledStartUtc: 'desc' },
-      select: { id: true },
-    })
-    if (latest) {
-      mode = 'fallback-latest'
-      targetRaceIds = [latest.id]
-    }
   }
 
   console.log(


### PR DESCRIPTION
## Summary
- remove the automatic `fallback-latest` path from `/api/cron/ingest-results`
- let idle scheduled runs return the existing `No races to process` response
- keep explicit `raceId` and `force: true` processing paths unchanged

Closes #89

## Test Plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`