### PR TITLE
Propagate live classification failures

### DIFF
--- a/src/lib/f1/providers/openf1.ts
+++ b/src/lib/f1/providers/openf1.ts
@@ -200,16 +200,9 @@ export class OpenF1Provider implements F1ProviderAdapter {
   async getLiveClassification(
     sessionKey: number,
   ): Promise<NormalizedLiveClassification | null> {
-    let raw: OpenF1Position[]
-
-    try {
-      raw = await openF1Fetch<OpenF1Position>(
-        `/position?session_key=${sessionKey}`,
-      )
-    } catch {
-      // No data available yet — not an error for live classification
-      return null
-    }
+    const raw = await openF1Fetch<OpenF1Position>(
+      `/position?session_key=${sessionKey}`,
+    )
 
     if (raw.length === 0) return null
 


### PR DESCRIPTION
## Summary
- stop swallowing OpenF1 fetch errors in `getLiveClassification`
- preserve `null` only for the valid empty-position-feed case
- let provider HTTP/network/schema failures remain visible to callers and monitoring

Closes #91

## Test Plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`