### PR TITLE
Disable slotted Button while loading

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -64,18 +64,35 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       loading = false,
       disabled,
       children,
+      onClick,
+      'aria-disabled': ariaDisabled,
       ...props
     },
     ref,
   ) => {
     const Comp = asChild ? Slot : 'button'
+    const isDisabled = disabled || loading
+    const handleClick: React.MouseEventHandler<HTMLButtonElement> = (event) => {
+      if (asChild && isDisabled) {
+        event.preventDefault()
+        event.stopPropagation()
+        return
+      }
+      onClick?.(event)
+    }
 
     return (
       <Comp
         ref={ref}
-        className={cn(buttonVariants({ variant, size, fullWidth, className }))}
-        disabled={disabled || loading}
+        className={cn(
+          buttonVariants({ variant, size, fullWidth, className }),
+          asChild && isDisabled && 'opacity-40 cursor-not-allowed pointer-events-none',
+        )}
+        disabled={asChild ? undefined : isDisabled}
+        aria-disabled={asChild && isDisabled ? true : ariaDisabled}
+        data-disabled={isDisabled ? '' : undefined}
         {...props}
+        onClick={handleClick}
       >
         {loading && <Loader2 className="h-4 w-4 animate-spin shrink-0" />}
         {children}


### PR DESCRIPTION
## Summary
- keep native `button` rendering on the real `disabled` attribute
- add slotted disabled handling with `aria-disabled`, `data-disabled`, disabled styling, and a click guard
- ensure `loading` suppresses interaction for `Button asChild` links and other non-button children

Closes #95

## Test Plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`