### PR TITLE
Reject malformed tutorial JSON

### DIFF
--- a/src/app/api/users/tutorial/route.ts
+++ b/src/app/api/users/tutorial/route.ts
@@ -11,10 +11,13 @@ export async function PATCH(request: NextRequest) {
   }
 
   let body: { dismissed?: unknown } = {}
-  try {
-    body = await request.json()
-  } catch {
-    // Empty body is treated as dismiss=true for this simple endpoint.
+  const rawBody = await request.text()
+  if (rawBody.trim().length > 0) {
+    try {
+      body = JSON.parse(rawBody)
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+    }
   }
 
   if (body.dismissed === false) {


### PR DESCRIPTION
## Summary
- read the tutorial dismissal request body as text so empty bodies can still default to dismissal
- reject malformed non-empty JSON with `400 Invalid JSON body`
- keep `dismissed: false` validation unchanged

Closes #98

## Test Plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`