### PR TITLE
Reject sessions for deleted users

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -73,6 +73,9 @@ export const auth = (async (...args: any[]) => {
     where: { id: session.user.id },
     select: { sessionValidAfter: true },
   });
+  if (!user) {
+    return null;
+  }
 
   const sessionIssuedAtMs = session.user.sessionIssuedAtMs;
 
@@ -81,7 +84,7 @@ export const auth = (async (...args: any[]) => {
   // ms-precise sessionValidAfter set at user-creation time and get rejected
   // immediately on the very first authenticated request.
   if (
-    user?.sessionValidAfter &&
+    user.sessionValidAfter &&
     typeof sessionIssuedAtMs === "number" &&
     sessionIssuedAtMs < Math.floor(user.sessionValidAfter.getTime() / 1000) * 1000
   ) {

--- a/src/lib/auth/mobileAuth.ts
+++ b/src/lib/auth/mobileAuth.ts
@@ -59,9 +59,12 @@ export async function mobileAuth(req: Request): Promise<Session | null> {
       where: { id: userId },
       select: { sessionValidAfter: true },
     })
+    if (!user) {
+      return null
+    }
 
     if (
-      user?.sessionValidAfter &&
+      user.sessionValidAfter &&
       sessionIssuedAtMs !== null &&
       sessionIssuedAtMs <
         Math.floor(user.sessionValidAfter.getTime() / 1000) * 1000


### PR DESCRIPTION
## Summary
- make the Auth.js wrapper return `null` when a session user id no longer exists in the database
- apply the same deleted-user rejection to mobile bearer tokens
- preserve existing `sessionValidAfter` revocation checks for found users and mobile DB-outage tolerance

Closes #102

## Test Plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`