### PR TITLE
Add account deletion route tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "prisma generate && next build",
     "start": "next start",
+    "test:routes": "node --test src/app/api/account/delete-handler.test.mjs",
     "lint": "next lint",
     "db:push": "prisma db push",
     "db:studio": "prisma studio",

--- a/src/app/api/account/delete-handler.js
+++ b/src/app/api/account/delete-handler.js
@@ -1,0 +1,18 @@
+export async function deleteAccountForSession(
+  req,
+  { auth, mobileAuth, deleteUser, logger = console },
+) {
+  const session = (await auth()) ?? (await mobileAuth(req))
+  if (!session?.user?.id) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    await deleteUser(session.user.id)
+    logger.log(`[account/delete] userId=${session.user.id}`)
+    return Response.json({ ok: true })
+  } catch (err) {
+    logger.error('[account/delete] failed:', err)
+    return Response.json({ error: 'Deletion failed' }, { status: 500 })
+  }
+}

--- a/src/app/api/account/delete-handler.test.mjs
+++ b/src/app/api/account/delete-handler.test.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { deleteAccountForSession } from './delete-handler.js'
+
+function request() {
+  return new Request('https://example.test/api/account', { method: 'DELETE' })
+}
+
+function deps(overrides = {}) {
+  const calls = []
+  return {
+    calls,
+    auth: async () => null,
+    mobileAuth: async () => null,
+    deleteUser: async (userId) => {
+      calls.push(userId)
+    },
+    logger: { log() {}, error() {} },
+    ...overrides,
+  }
+}
+
+test('DELETE /api/account returns 401 when unauthenticated', async () => {
+  const d = deps()
+  const response = await deleteAccountForSession(request(), d)
+
+  assert.equal(response.status, 401)
+  assert.deepEqual(await response.json(), { error: 'Unauthorized' })
+  assert.deepEqual(d.calls, [])
+})
+
+test('DELETE /api/account deletes the cookie-authenticated user', async () => {
+  const d = deps({
+    auth: async () => ({ user: { id: 'web-user' } }),
+  })
+
+  const response = await deleteAccountForSession(request(), d)
+
+  assert.equal(response.status, 200)
+  assert.deepEqual(await response.json(), { ok: true })
+  assert.deepEqual(d.calls, ['web-user'])
+})
+
+test('DELETE /api/account falls back to mobile bearer auth', async () => {
+  const d = deps({
+    mobileAuth: async () => ({ user: { id: 'mobile-user' } }),
+  })
+
+  const response = await deleteAccountForSession(request(), d)
+
+  assert.equal(response.status, 200)
+  assert.deepEqual(await response.json(), { ok: true })
+  assert.deepEqual(d.calls, ['mobile-user'])
+})
+
+test('DELETE /api/account reports deletion failures without success', async () => {
+  const d = deps({
+    auth: async () => ({ user: { id: 'web-user' } }),
+    deleteUser: async (userId) => {
+      d.calls.push(userId)
+      throw new Error('database unavailable')
+    },
+  })
+
+  const response = await deleteAccountForSession(request(), d)
+
+  assert.equal(response.status, 500)
+  assert.deepEqual(await response.json(), { error: 'Deletion failed' })
+  assert.deepEqual(d.calls, ['web-user'])
+})

--- a/src/app/api/account/route.ts
+++ b/src/app/api/account/route.ts
@@ -8,23 +8,11 @@
  *   Account, Session, PickSet → ScoreBreakdown, FriendRequest (both directions)
  */
 
-import { NextResponse } from 'next/server'
 import { auth } from '@/auth'
 import { mobileAuth } from '@/lib/auth/mobileAuth'
 import { deleteUser } from '@/lib/services/user.service'
+import { deleteAccountForSession } from './delete-handler'
 
 export async function DELETE(req: Request) {
-  const session = (await auth()) ?? (await mobileAuth(req))
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
-
-  try {
-    await deleteUser(session.user.id)
-    console.log(`[account/delete] userId=${session.user.id}`)
-    return NextResponse.json({ ok: true })
-  } catch (err) {
-    console.error('[account/delete] failed:', err)
-    return NextResponse.json({ error: 'Deletion failed' }, { status: 500 })
-  }
+  return deleteAccountForSession(req, { auth, mobileAuth, deleteUser })
 }


### PR DESCRIPTION
## Summary
- extract account deletion route decision logic into an injectable helper
- add Node route tests for unauthenticated, cookie-auth, mobile-auth, and delete failure paths
- add a focused `test:routes` script

Closes #112

## Test Plan
- [x] `npm run test:routes`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`