### PR TITLE
Prevent username POST reset

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "prisma generate && next build",
     "start": "next start",
-    "test:routes": "node --test src/app/api/account/delete-handler.test.mjs",
+    "test:routes": "node --test src/app/api/account/delete-handler.test.mjs src/app/api/users/username/post-handler.test.mjs",
     "lint": "next lint",
     "db:push": "prisma db push",
     "db:studio": "prisma studio",

--- a/src/app/api/users/username/post-handler.js
+++ b/src/app/api/users/username/post-handler.js
@@ -1,0 +1,55 @@
+export async function handleUsernamePost(
+  req,
+  {
+    auth,
+    mobileAuth,
+    setUsername,
+    validateUsernameFormat,
+    isUniqueConstraintError = (_err) => false,
+  },
+) {
+  const session = (await auth()) ?? (await mobileAuth(req))
+  if (!session?.user?.id) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  let body
+  try {
+    body = await req.json()
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 })
+  }
+
+  const { username } = body
+
+  if (typeof username !== "string" || !username) {
+    return Response.json(
+      { error: "username must be a non-empty string" },
+      { status: 400 },
+    )
+  }
+
+  const formatCheck = validateUsernameFormat(username)
+  if (!formatCheck.valid) {
+    return Response.json({ error: formatCheck.error }, { status: 400 })
+  }
+
+  let stored
+  try {
+    stored = await setUsername(session.user.id, username)
+  } catch (err) {
+    if (isUniqueConstraintError(err)) {
+      return Response.json({ error: "Username is already taken" }, { status: 409 })
+    }
+
+    const message = err instanceof Error ? err.message : "Unknown error"
+
+    if (message.includes("already taken")) {
+      return Response.json({ error: message }, { status: 409 })
+    }
+
+    return Response.json({ error: message }, { status: 400 })
+  }
+
+  return Response.json({ ok: true, username: stored })
+}

--- a/src/app/api/users/username/post-handler.test.mjs
+++ b/src/app/api/users/username/post-handler.test.mjs
@@ -1,0 +1,48 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+
+import { handleUsernamePost } from "./post-handler.js"
+
+function jsonRequest(body) {
+  return new Request("http://localhost/api/users/username", {
+    method: "POST",
+    body: JSON.stringify(body),
+  })
+}
+
+function validFormat() {
+  return { valid: true }
+}
+
+test("POST rejects users that already set a username", async () => {
+  let storedUsername = "oldname"
+
+  const response = await handleUsernamePost(jsonRequest({ username: "newname" }), {
+    auth: async () => ({ user: { id: "user-1" } }),
+    mobileAuth: async () => null,
+    validateUsernameFormat: validFormat,
+    setUsername: async () => {
+      throw new Error("Username is already set")
+    },
+  })
+
+  assert.equal(response.status, 400)
+  assert.deepEqual(await response.json(), { error: "Username is already set" })
+  assert.equal(storedUsername, "oldname")
+})
+
+test("POST sets an initial username", async () => {
+  const response = await handleUsernamePost(jsonRequest({ username: "FirstName" }), {
+    auth: async () => ({ user: { id: "user-1" } }),
+    mobileAuth: async () => null,
+    validateUsernameFormat: validFormat,
+    setUsername: async (userId, username) => {
+      assert.equal(userId, "user-1")
+      assert.equal(username, "FirstName")
+      return "firstname"
+    },
+  })
+
+  assert.equal(response.status, 200)
+  assert.deepEqual(await response.json(), { ok: true, username: "firstname" })
+})

--- a/src/app/api/users/username/route.ts
+++ b/src/app/api/users/username/route.ts
@@ -3,6 +3,7 @@ import type { NextRequest } from "next/server"
 import { Prisma } from "@prisma/client"
 import { auth } from "@/auth"
 import { mobileAuth } from "@/lib/auth/mobileAuth"
+import { handleUsernamePost } from "./post-handler"
 import {
   validateUsernameFormat,
   setUsername,
@@ -22,55 +23,14 @@ const NO_STORE_HEADERS = {
 // ─────────────────────────────────────────────────────────────────────────────
 
 export async function POST(req: NextRequest) {
-  const session = (await auth()) ?? (await mobileAuth(req))
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
-  }
-
-  let body: unknown
-  try {
-    body = await req.json()
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
-  }
-
-  const { username } = body as { username?: unknown }
-
-  if (typeof username !== "string" || !username) {
-    return NextResponse.json(
-      { error: "username must be a non-empty string" },
-      { status: 400 },
-    )
-  }
-
-  // Validate format first — avoid the DB round-trip for obviously invalid input
-  const formatCheck = validateUsernameFormat(username)
-  if (!formatCheck.valid) {
-    return NextResponse.json({ error: formatCheck.error }, { status: 400 })
-  }
-
-  let stored: string
-  try {
-    // setUsername internally re-validates format + checks availability atomically
-    stored = await setUsername(session.user.id, username)
-  } catch (err) {
-    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
-      return NextResponse.json({ error: "Username is already taken" }, { status: 409 })
-    }
-
-    const message = err instanceof Error ? err.message : "Unknown error"
-
-    if (message.includes("already taken")) {
-      return NextResponse.json({ error: message }, { status: 409 })
-    }
-
-    return NextResponse.json({ error: message }, { status: 400 })
-  }
-
-  // Return the stored (lowercased) username so the iOS client's optimistic
-  // update matches what the next /api/users/me call will return — avoids the
-  // displayed username flicker between input case and stored case after relaunch.
-  return NextResponse.json({ ok: true, username: stored })
+  return handleUsernamePost(req, {
+    auth,
+    mobileAuth,
+    setUsername,
+    validateUsernameFormat,
+    isUniqueConstraintError: (err: unknown) =>
+      err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002",
+  })
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/lib/services/user.service.ts
+++ b/src/lib/services/user.service.ts
@@ -111,13 +111,16 @@ export async function setUsername(
       throw new Error(`Username "${username}" is already taken`)
     }
 
-    await tx.user.update({
-      where: { id: userId },
+    const updated = await tx.user.updateMany({
+      where: { id: userId, usernameSet: false },
       data: {
         publicUsername: stored,
         usernameSet: true,
       },
     })
+    if (updated.count !== 1) {
+      throw new Error('Username is already set')
+    }
   })
 
   return stored


### PR DESCRIPTION
## Summary
- enforce initial username setup atomically with `usernameSet: false`
- extract the username POST decision path into a focused testable helper
- add route coverage for direct POST misuse after a username is already set

Closes #114

## Test Plan
- [x] `npm run test:routes`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`