### PR TITLE
Sanitize pick save errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "prisma generate && next build",
     "start": "next start",
-    "test:routes": "node --test src/app/api/account/delete-handler.test.mjs src/app/api/users/username/post-handler.test.mjs",
+    "test:routes": "node --test src/app/api/account/delete-handler.test.mjs src/app/api/users/username/post-handler.test.mjs src/app/api/picks/post-handler.test.mjs",
     "lint": "next lint",
     "db:push": "prisma db push",
     "db:studio": "prisma studio",

--- a/src/app/api/picks/post-handler.js
+++ b/src/app/api/picks/post-handler.js
@@ -1,0 +1,55 @@
+export async function handlePickPost(
+  req,
+  {
+    auth,
+    mobileAuth,
+    createPickSchema,
+    createOrUpdatePick,
+    isValidationError,
+    getValidationIssues,
+    logger = console,
+  },
+) {
+  const session = (await auth()) ?? (await mobileAuth(req))
+  if (!session?.user?.id) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  let body
+  try {
+    body = await req.json()
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 })
+  }
+
+  let input
+  try {
+    input = createPickSchema.parse(body)
+  } catch (err) {
+    if (isValidationError(err)) {
+      return Response.json(
+        { error: "Validation failed", issues: getValidationIssues(err) },
+        { status: 400 },
+      )
+    }
+    throw err
+  }
+
+  try {
+    const pick = await createOrUpdatePick(session.user.id, input)
+    return Response.json({ pick })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error"
+
+    if (message.toLowerCase().includes("locked")) {
+      return Response.json({ error: message }, { status: 423 })
+    }
+
+    if (message.includes("not found")) {
+      return Response.json({ error: message }, { status: 404 })
+    }
+
+    logger.error("Failed to save pick", err)
+    return Response.json({ error: "Failed to save pick" }, { status: 500 })
+  }
+}

--- a/src/app/api/picks/post-handler.test.mjs
+++ b/src/app/api/picks/post-handler.test.mjs
@@ -1,0 +1,49 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+
+import { handlePickPost } from "./post-handler.js"
+
+function jsonRequest(body) {
+  return new Request("http://localhost/api/picks", {
+    method: "POST",
+    body: JSON.stringify(body),
+  })
+}
+
+function dependencies(overrides = {}) {
+  return {
+    auth: async () => ({ user: { id: "user-1" } }),
+    mobileAuth: async () => null,
+    createPickSchema: { parse: (body) => body },
+    isValidationError: () => false,
+    getValidationIssues: () => [],
+    logger: { error: () => {} },
+    ...overrides,
+  }
+}
+
+test("POST returns a generic 500 for unexpected pick save failures", async () => {
+  const logs = []
+  const response = await handlePickPost(jsonRequest({ raceId: "race-1" }), dependencies({
+    createOrUpdatePick: async () => {
+      throw new Error("Prisma connection string leaked")
+    },
+    logger: { error: (...args) => logs.push(args) },
+  }))
+
+  assert.equal(response.status, 500)
+  assert.deepEqual(await response.json(), { error: "Failed to save pick" })
+  assert.equal(logs.length, 1)
+  assert.equal(String(logs[0][1].message).includes("Prisma connection"), true)
+})
+
+test("POST preserves locked race domain errors", async () => {
+  const response = await handlePickPost(jsonRequest({ raceId: "race-1" }), dependencies({
+    createOrUpdatePick: async () => {
+      throw new Error("Race is locked")
+    },
+  }))
+
+  assert.equal(response.status, 423)
+  assert.deepEqual(await response.json(), { error: "Race is locked" })
+})

--- a/src/app/api/picks/route.ts
+++ b/src/app/api/picks/route.ts
@@ -7,58 +7,22 @@ import {
   getPickForRace,
   CreatePickSchema,
 } from "@/lib/services/pick.service"
-import { isRaceLocked } from "@/lib/services/lock.service"
 import { ZodError } from "zod"
+import { handlePickPost } from "./post-handler"
 
 // ─────────────────────────────────────────────────────────────────────────────
 // POST /api/picks — create or update a pick set
 // ─────────────────────────────────────────────────────────────────────────────
 
 export async function POST(req: NextRequest) {
-  const session = (await auth()) ?? (await mobileAuth(req))
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
-  }
-
-  let body: unknown
-  try {
-    body = await req.json()
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
-  }
-
-  // Validate input shape with the same Zod schema used by the service
-  let input: ReturnType<typeof CreatePickSchema.parse>
-  try {
-    input = CreatePickSchema.parse(body)
-  } catch (err) {
-    if (err instanceof ZodError) {
-      return NextResponse.json(
-        { error: "Validation failed", issues: err.issues },
-        { status: 400 },
-      )
-    }
-    throw err
-  }
-
-  try {
-    const pick = await createOrUpdatePick(session.user.id, input)
-    return NextResponse.json({ pick })
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "Unknown error"
-
-    // "locked" signals appear in the error message from both isRaceLocked
-    // and isPickSetLocked checks inside the service.
-    if (message.toLowerCase().includes("locked")) {
-      return NextResponse.json({ error: message }, { status: 423 }) // 423 Locked
-    }
-
-    if (message.includes("not found")) {
-      return NextResponse.json({ error: message }, { status: 404 })
-    }
-
-    return NextResponse.json({ error: message }, { status: 400 })
-  }
+  return handlePickPost(req, {
+    auth,
+    mobileAuth,
+    createPickSchema: CreatePickSchema,
+    createOrUpdatePick,
+    isValidationError: (err: unknown) => err instanceof ZodError,
+    getValidationIssues: (err: ZodError) => err.issues,
+  })
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- sanitize unexpected `POST /api/picks` save failures to a generic 500 response
- preserve locked and not-found domain error responses
- add focused route tests for internal error leakage and locked-race behavior

Closes #116

## Test Plan
- [x] `npm run test:routes`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`