### PR TITLE
Use race-specific leaderboard rank

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "prisma generate && next build",
     "start": "next start",
-    "test:routes": "node --test src/app/api/account/delete-handler.test.mjs src/app/api/users/username/post-handler.test.mjs src/app/api/picks/post-handler.test.mjs",
+    "test:routes": "node --test src/app/api/account/delete-handler.test.mjs src/app/api/users/username/post-handler.test.mjs src/app/api/picks/post-handler.test.mjs src/app/api/leaderboard/get-handler.test.mjs",
     "lint": "next lint",
     "db:push": "prisma db push",
     "db:studio": "prisma studio",

--- a/src/app/api/leaderboard/get-handler.js
+++ b/src/app/api/leaderboard/get-handler.js
@@ -1,0 +1,43 @@
+export async function handleLeaderboardGet(
+  request,
+  {
+    auth,
+    mobileAuth,
+    getActiveSeason,
+    getGlobalLeaderboard,
+    getFriendsLeaderboard,
+    getUserLeaderboardRank,
+  },
+) {
+  const { searchParams } = request.nextUrl
+  const scope = searchParams.get("scope") === "friends" ? "friends" : "global"
+  const sort = searchParams.get("sort") ?? "season"
+
+  const session = (await auth()) ?? (await mobileAuth(request))
+  const userId = session?.user?.id ?? null
+  if (scope === "friends" && !userId) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const seasonIdParam = searchParams.get("seasonId")
+  let seasonId = seasonIdParam
+
+  if (!seasonId) {
+    const active = await getActiveSeason()
+    seasonId = active?.id ?? null
+  }
+
+  if (!seasonId) {
+    return Response.json({ rows: [], userRank: null, userRow: null })
+  }
+
+  const rows =
+    scope === "friends"
+      ? await getFriendsLeaderboard(userId, seasonId, sort)
+      : await getGlobalLeaderboard(seasonId, sort, 20)
+
+  const userRank = userId ? await getUserLeaderboardRank(userId, seasonId, sort) : null
+  const userRow = userId ? (rows.find((row) => row.userId === userId) ?? null) : null
+
+  return Response.json({ rows, userRank, userRow })
+}

--- a/src/app/api/leaderboard/get-handler.test.mjs
+++ b/src/app/api/leaderboard/get-handler.test.mjs
@@ -1,0 +1,59 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+
+import { handleLeaderboardGet } from "./get-handler.js"
+
+function request(url) {
+  return {
+    nextUrl: new URL(url),
+  }
+}
+
+function dependencies(overrides = {}) {
+  return {
+    auth: async () => ({ user: { id: "user-1" } }),
+    mobileAuth: async () => null,
+    getActiveSeason: async () => ({ id: "season-1" }),
+    getGlobalLeaderboard: async () => [],
+    getFriendsLeaderboard: async () => [],
+    getUserLeaderboardRank: async () => null,
+    ...overrides,
+  }
+}
+
+test("GET uses the requested race sort when computing userRank", async () => {
+  const rankCalls = []
+  const response = await handleLeaderboardGet(
+    request("http://localhost/api/leaderboard?sort=race-1&seasonId=season-1"),
+    dependencies({
+      getGlobalLeaderboard: async (_seasonId, sort) => [
+        { userId: "user-1", rank: sort === "race-1" ? 3 : 9 },
+      ],
+      getUserLeaderboardRank: async (userId, seasonId, sort) => {
+        rankCalls.push({ userId, seasonId, sort })
+        return sort === "race-1" ? 3 : 9
+      },
+    }),
+  )
+
+  assert.equal(response.status, 200)
+  assert.deepEqual(rankCalls, [{ userId: "user-1", seasonId: "season-1", sort: "race-1" }])
+  assert.equal((await response.json()).userRank, 3)
+})
+
+test("GET keeps season as the default userRank sort", async () => {
+  const rankCalls = []
+  const response = await handleLeaderboardGet(
+    request("http://localhost/api/leaderboard?seasonId=season-1"),
+    dependencies({
+      getUserLeaderboardRank: async (userId, seasonId, sort) => {
+        rankCalls.push({ userId, seasonId, sort })
+        return 2
+      },
+    }),
+  )
+
+  assert.equal(response.status, 200)
+  assert.deepEqual(rankCalls, [{ userId: "user-1", seasonId: "season-1", sort: "season" }])
+  assert.equal((await response.json()).userRank, 2)
+})

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -1,51 +1,21 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { auth } from '@/auth'
 import { mobileAuth } from '@/lib/auth/mobileAuth'
 import {
   getGlobalLeaderboard,
   getFriendsLeaderboard,
-  getUserSeasonRank,
+  getUserLeaderboardRank,
 } from '@/lib/services/leaderboard.service'
 import { getActiveSeason } from '@/lib/services/race.service'
+import { handleLeaderboardGet } from './get-handler'
 
 export async function GET(request: NextRequest) {
-  // Parse query params
-  const { searchParams } = request.nextUrl
-  const scope = searchParams.get('scope') === 'friends' ? 'friends' : 'global'
-  // sort = 'season' (full season) or a specific raceId
-  const sort = searchParams.get('sort') ?? 'season'
-
-  // Auth is required for Friends scope and optional for Global scope.
-  const session = (await auth()) ?? (await mobileAuth(request))
-  const userId = session?.user?.id ?? null
-  if (scope === 'friends' && !userId) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
-
-  // Determine season — prefer explicit param, fall back to active season
-  const seasonIdParam = searchParams.get('seasonId')
-  let seasonId: string | null = seasonIdParam
-
-  if (!seasonId) {
-    const active = await getActiveSeason()
-    seasonId = active?.id ?? null
-  }
-
-  if (!seasonId) {
-    return NextResponse.json({ rows: [], userRank: null, userRow: null })
-  }
-
-  // Fetch rows
-  const rows =
-    scope === 'friends'
-      ? await getFriendsLeaderboard(userId, seasonId, sort)
-      : await getGlobalLeaderboard(seasonId, sort, 20)
-
-  // User's own rank on the global season board (for pinned row logic)
-  const userRank = userId ? await getUserSeasonRank(userId, seasonId) : null
-
-  // Find the user's row in the returned set (may be null if they're outside top 20)
-  const userRow = userId ? (rows.find((r) => r.userId === userId) ?? null) : null
-
-  return NextResponse.json({ rows, userRank, userRow })
+  return handleLeaderboardGet(request, {
+    auth,
+    mobileAuth,
+    getActiveSeason,
+    getGlobalLeaderboard,
+    getFriendsLeaderboard,
+    getUserLeaderboardRank,
+  })
 }

--- a/src/lib/services/leaderboard.service.ts
+++ b/src/lib/services/leaderboard.service.ts
@@ -243,14 +243,22 @@ export async function getFriendsLeaderboard(
 }
 
 /**
- * Get a single user's rank on the global season leaderboard.
+ * Get a single user's rank on the selected global leaderboard.
  * Returns null if the user has no scored picks in the season.
  */
+export async function getUserLeaderboardRank(
+  userId: string,
+  seasonId: string,
+  sort: string,
+): Promise<number | null> {
+  const leaderboard = await getGlobalLeaderboard(seasonId, sort, 10_000)
+  const entry = leaderboard.find((row) => row.userId === userId)
+  return entry?.rank ?? null
+}
+
 export async function getUserSeasonRank(
   userId: string,
   seasonId: string,
 ): Promise<number | null> {
-  const leaderboard = await getGlobalLeaderboard(seasonId, 'season', 10_000)
-  const entry = leaderboard.find((row) => row.userId === userId)
-  return entry?.rank ?? null
+  return getUserLeaderboardRank(userId, seasonId, 'season')
 }


### PR DESCRIPTION
## Summary
- compute `userRank` using the same `sort` dimension as leaderboard rows
- keep `getUserSeasonRank` as a season-specific wrapper
- add focused route tests for race-specific rank sort and default season rank sort

Closes #119

## Test Plan
- [x] `npm run test:routes`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`