### PR TITLE
Reset PickForm selections when race changes

### DIFF
--- a/src/components/picks/PickForm.tsx
+++ b/src/components/picks/PickForm.tsx
@@ -242,15 +242,32 @@ export function PickForm({
   existingPick,
   isLocked,
 }: PickFormProps) {
-  const [selected, setSelected] = React.useState<SelectedDrivers>({
-    tenth: existingPick?.tenthPlaceDriverId ?? null,
-    winner: existingPick?.winnerDriverId ?? null,
-    dnf: existingPick?.dnfDriverId ?? null,
-  })
+  const tenthPlaceDriverId = existingPick?.tenthPlaceDriverId ?? null
+  const winnerDriverId = existingPick?.winnerDriverId ?? null
+  const dnfDriverId = existingPick?.dnfDriverId ?? null
+
+  const initialSelected = React.useMemo(
+    () => ({
+      tenth: tenthPlaceDriverId,
+      winner: winnerDriverId,
+      dnf: dnfDriverId,
+    }),
+    [tenthPlaceDriverId, winnerDriverId, dnfDriverId],
+  )
+
+  const [selected, setSelected] = React.useState<SelectedDrivers>(() =>
+    initialSelected,
+  )
   const [status, setStatus] = React.useState<'idle' | 'loading' | 'success' | 'error'>('idle')
   const [errorMsg, setErrorMsg] = React.useState<string | null>(null)
 
   const groups = React.useMemo(() => groupByTeam(entrants), [entrants])
+
+  React.useEffect(() => {
+    setSelected(initialSelected)
+    setStatus('idle')
+    setErrorMsg(null)
+  }, [race.id, initialSelected])
 
   const handleSelect = (slot: PickSlot, driverId: string) => {
     setSelected((prev) => ({


### PR DESCRIPTION
## Summary
- derive initial PickForm selections from the current persisted pick ids
- reset selected drivers, save status, and errors when `race.id` or persisted pick ids change
- avoid carrying stale selections across reused PickForm instances

Closes #121

## Test Plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

No React component test harness exists in this repo; this was verified with the required static/build checks.