### PR TITLE
Fix sync-schedule driver fetch throttling

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "prisma generate && next build",
     "start": "next start",
-    "test:routes": "node --test src/app/api/account/delete-handler.test.mjs src/app/api/users/username/post-handler.test.mjs src/app/api/picks/post-handler.test.mjs src/app/api/leaderboard/get-handler.test.mjs",
+    "test:routes": "node --test src/app/api/account/delete-handler.test.mjs src/app/api/users/username/post-handler.test.mjs src/app/api/picks/post-handler.test.mjs src/app/api/leaderboard/get-handler.test.mjs src/app/api/cron/sync-schedule/driver-fetch.test.mjs",
     "lint": "next lint",
     "db:push": "prisma db push",
     "db:studio": "prisma studio",

--- a/src/app/api/cron/sync-schedule/driver-fetch.d.ts
+++ b/src/app/api/cron/sync-schedule/driver-fetch.d.ts
@@ -1,0 +1,15 @@
+export function fetchDriversForSessions<
+  TSession extends { sessionKey: number },
+  TDriver,
+>(
+  sessions: TSession[],
+  dependencies: {
+    getDriversForSession: (sessionKey: number) => Promise<TDriver[]>
+  },
+  options?: {
+    concurrency?: number
+    logger?: {
+      warn: (message: string) => void
+    }
+  },
+): Promise<Array<{ session: TSession; drivers: TDriver[] }>>

--- a/src/app/api/cron/sync-schedule/driver-fetch.js
+++ b/src/app/api/cron/sync-schedule/driver-fetch.js
@@ -1,0 +1,37 @@
+export async function fetchDriversForSessions(
+  sessions,
+  { getDriversForSession },
+  { concurrency = 4, logger = console } = {},
+) {
+  const limit = Math.max(1, Math.floor(concurrency))
+  const results = new Array(sessions.length)
+  let nextIndex = 0
+
+  async function worker() {
+    while (nextIndex < sessions.length) {
+      const index = nextIndex
+      nextIndex++
+      const session = sessions[index]
+
+      try {
+        const drivers = await getDriversForSession(session.sessionKey)
+        if (drivers.length === 0) {
+          logger.warn(
+            `[f10:cron:sync-schedule] no drivers for session=${session.sessionKey}`,
+          )
+        }
+        results[index] = { session, drivers }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        logger.warn(
+          `[f10:cron:sync-schedule] driver fetch FAIL session=${session.sessionKey}: ${message}`,
+        )
+        results[index] = { session, drivers: [] }
+      }
+    }
+  }
+
+  const workerCount = Math.min(limit, sessions.length)
+  await Promise.all(Array.from({ length: workerCount }, () => worker()))
+  return results
+}

--- a/src/app/api/cron/sync-schedule/driver-fetch.test.mjs
+++ b/src/app/api/cron/sync-schedule/driver-fetch.test.mjs
@@ -1,0 +1,83 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+
+import { fetchDriversForSessions } from "./driver-fetch.js"
+
+function deferred() {
+  let resolve
+  const promise = new Promise((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+test("fetchDriversForSessions caps concurrent driver requests", async () => {
+  const sessions = Array.from({ length: 6 }, (_, index) => ({
+    sessionKey: index + 1,
+  }))
+  const releases = sessions.map(() => deferred())
+  let inFlight = 0
+  let maxInFlight = 0
+  let started = 0
+
+  const resultPromise = fetchDriversForSessions(
+    sessions,
+    {
+      getDriversForSession: async (sessionKey) => {
+        started++
+        inFlight++
+        maxInFlight = Math.max(maxInFlight, inFlight)
+        await releases[sessionKey - 1].promise
+        inFlight--
+        return [{ driverNumber: sessionKey }]
+      },
+    },
+    { concurrency: 2 },
+  )
+
+  await new Promise((resolve) => setImmediate(resolve))
+  assert.equal(started, 2)
+
+  releases[0].resolve()
+  await new Promise((resolve) => setImmediate(resolve))
+  assert.equal(started, 3)
+
+  for (const release of releases.slice(1)) {
+    release.resolve()
+  }
+
+  const results = await resultPromise
+  assert.equal(maxInFlight, 2)
+  assert.deepEqual(
+    results.map(({ drivers }) => drivers[0].driverNumber),
+    [1, 2, 3, 4, 5, 6],
+  )
+})
+
+test("fetchDriversForSessions logs failed and empty driver fetches", async () => {
+  const warnings = []
+  const sessions = [{ sessionKey: 11 }, { sessionKey: 12 }, { sessionKey: 13 }]
+
+  const results = await fetchDriversForSessions(
+    sessions,
+    {
+      getDriversForSession: async (sessionKey) => {
+        if (sessionKey === 11) throw new Error("rate limited")
+        if (sessionKey === 12) return []
+        return [{ driverNumber: sessionKey }]
+      },
+    },
+    {
+      concurrency: 2,
+      logger: { warn: (message) => warnings.push(message) },
+    },
+  )
+
+  assert.deepEqual(
+    results.map(({ drivers }) => drivers.length),
+    [0, 0, 1],
+  )
+  assert.equal(warnings.length, 2)
+  assert.match(warnings[0], /driver fetch FAIL session=11: rate limited/)
+  assert.match(warnings[1], /no drivers for session=12/)
+})

--- a/src/app/api/cron/sync-schedule/route.ts
+++ b/src/app/api/cron/sync-schedule/route.ts
@@ -10,6 +10,7 @@ import { NextResponse } from "next/server"
 import type { NextRequest } from "next/server"
 import { db } from "@/lib/db/client"
 import { createF1Provider } from "@/lib/f1/adapter"
+import { fetchDriversForSessions } from "./driver-fetch"
 
 // ─── Auth helper ──────────────────────────────────────────────────────────────
 
@@ -111,18 +112,12 @@ export async function POST(req: NextRequest) {
     ...qualifyingSessions,
   ]
 
-  // ── 5. Fetch drivers for all relevant sessions in parallel ─────────────────
+  // ── 5. Fetch drivers for all relevant sessions with bounded concurrency ────
   type DriverList = Awaited<ReturnType<typeof provider.getDriversForSession>>
-  const sessionDrivers = await Promise.all(
-    driverFetchSessions.map(async (session) => {
-      try {
-        const drivers = await provider.getDriversForSession(session.sessionKey)
-        return { session, drivers }
-      } catch {
-        return { session, drivers: [] as DriverList }
-      }
-    }),
-  )
+  const sessionDrivers = await fetchDriversForSessions(driverFetchSessions, {
+    getDriversForSession: (sessionKey: number) =>
+      provider.getDriversForSession(sessionKey),
+  })
 
   // ── 6. Upsert Race records (Race + Sprint sessions only) ───────────────────
   // For each Race row we also pair the qualifying session that precedes it


### PR DESCRIPTION
## Summary
- replace the unbounded sync-schedule driver-fetch burst with a bounded concurrency helper
- log per-session driver-fetch failures and empty driver responses
- add route-level regression coverage for concurrency limiting and logging

Closes #34

## Test Plan
- [x] node --test src/app/api/cron/sync-schedule/driver-fetch.test.mjs (fails before fix, passes after)
- [x] npm run test:routes
- [x] npx tsc --noEmit
- [x] npm run lint
- [x] npm run build

## Notes
- Did not run the live manual smoke against OpenF1/production data; the fix is covered with a deterministic concurrency regression test and the full local verification suite.