### PR TITLE
Detect seat-key drift in pick diagnostics

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "prisma generate && next build",
     "start": "next start",
     "test:routes": "node --test src/app/api/account/delete-handler.test.mjs src/app/api/users/username/post-handler.test.mjs src/app/api/picks/post-handler.test.mjs src/app/api/leaderboard/get-handler.test.mjs src/app/api/cron/sync-schedule/driver-fetch.test.mjs",
+    "test:scripts": "node --test scripts/find-cheated-picks.test.mjs",
     "lint": "next lint",
     "db:push": "prisma db push",
     "db:studio": "prisma studio",

--- a/scripts/find-cheated-picks.test.mjs
+++ b/scripts/find-cheated-picks.test.mjs
@@ -1,0 +1,45 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const source = await readFile(new URL("./find-cheated-picks.ts", import.meta.url), "utf8")
+const driftQuery = source.match(
+  /const drift = await db\.\$queryRaw<DriftRow\[]>`([\s\S]*?)ORDER BY r\."scheduledStartUtc" DESC/,
+)?.[1]
+
+assert.ok(driftQuery, "expected to find the snapshot drift SQL query")
+
+test("snapshot drift query compares protected driver and seat snapshot fields", () => {
+  for (const field of [
+    "tenthPlaceDriverId",
+    "lockedTenthPlaceDriverId",
+    "winnerDriverId",
+    "lockedWinnerDriverId",
+    "dnfDriverId",
+    "lockedDnfDriverId",
+    "tenthPlaceSeatKey",
+    "lockedTenthPlaceSeatKey",
+    "winnerSeatKey",
+    "lockedWinnerSeatKey",
+    "dnfSeatKey",
+    "lockedDnfSeatKey",
+  ]) {
+    assert.match(driftQuery, new RegExp(`ps\\."${field}"`))
+  }
+
+  for (const [liveField, lockedField] of [
+    ["tenthPlaceDriverId", "lockedTenthPlaceDriverId"],
+    ["winnerDriverId", "lockedWinnerDriverId"],
+    ["dnfDriverId", "lockedDnfDriverId"],
+    ["tenthPlaceSeatKey", "lockedTenthPlaceSeatKey"],
+    ["winnerSeatKey", "lockedWinnerSeatKey"],
+    ["dnfSeatKey", "lockedDnfSeatKey"],
+  ]) {
+    assert.match(
+      driftQuery,
+      new RegExp(
+        `ps\\."${liveField}"\\s+IS DISTINCT FROM\\s+ps\\."${lockedField}"`,
+      ),
+    )
+  }
+})

--- a/scripts/find-cheated-picks.ts
+++ b/scripts/find-cheated-picks.ts
@@ -42,10 +42,16 @@ type DriftRow = {
   raceStatus: string
   liveTenth: string
   lockedTenth: string | null
+  liveTenthSeatKey: string | null
+  lockedTenthSeatKey: string | null
   liveWinner: string
   lockedWinner: string | null
+  liveWinnerSeatKey: string | null
+  lockedWinnerSeatKey: string | null
   liveDnf: string
   lockedDnf: string | null
+  liveDnfSeatKey: string | null
+  lockedDnfSeatKey: string | null
 }
 
 async function main() {
@@ -87,19 +93,28 @@ async function main() {
       r.status::text                 AS "raceStatus",
       ps."tenthPlaceDriverId"        AS "liveTenth",
       ps."lockedTenthPlaceDriverId"  AS "lockedTenth",
+      ps."tenthPlaceSeatKey"         AS "liveTenthSeatKey",
+      ps."lockedTenthPlaceSeatKey"   AS "lockedTenthSeatKey",
       ps."winnerDriverId"            AS "liveWinner",
       ps."lockedWinnerDriverId"      AS "lockedWinner",
+      ps."winnerSeatKey"             AS "liveWinnerSeatKey",
+      ps."lockedWinnerSeatKey"       AS "lockedWinnerSeatKey",
       ps."dnfDriverId"               AS "liveDnf",
-      ps."lockedDnfDriverId"         AS "lockedDnf"
+      ps."lockedDnfDriverId"         AS "lockedDnf",
+      ps."dnfSeatKey"                AS "liveDnfSeatKey",
+      ps."lockedDnfSeatKey"          AS "lockedDnfSeatKey"
     FROM "PickSet" ps
     JOIN "Race" r ON r.id = ps."raceId"
     JOIN "User" u ON u.id = ps."userId"
     WHERE ps."lockedAt" IS NOT NULL
       AND ps."lockedTenthPlaceDriverId" IS NOT NULL
       AND (
-        ps."tenthPlaceDriverId" <> ps."lockedTenthPlaceDriverId" OR
-        ps."winnerDriverId"     <> ps."lockedWinnerDriverId"     OR
-        ps."dnfDriverId"        <> ps."lockedDnfDriverId"
+        ps."tenthPlaceDriverId" IS DISTINCT FROM ps."lockedTenthPlaceDriverId" OR
+        ps."winnerDriverId"     IS DISTINCT FROM ps."lockedWinnerDriverId"     OR
+        ps."dnfDriverId"        IS DISTINCT FROM ps."lockedDnfDriverId"        OR
+        ps."tenthPlaceSeatKey"  IS DISTINCT FROM ps."lockedTenthPlaceSeatKey"  OR
+        ps."winnerSeatKey"      IS DISTINCT FROM ps."lockedWinnerSeatKey"      OR
+        ps."dnfSeatKey"         IS DISTINCT FROM ps."lockedDnfSeatKey"
       )
     ORDER BY r."scheduledStartUtc" DESC
   `
@@ -131,7 +146,7 @@ async function main() {
 
   if (drift.length > 0) {
     console.log(
-      `[snapshot drift] Found ${drift.length} PickSet(s) where live driver IDs no longer match the locked snapshot — direct evidence of tampering (trigger missing/bypassed):\n`,
+      `[snapshot drift] Found ${drift.length} PickSet(s) where live driver/seat fields no longer match the locked snapshot — direct evidence of tampering (trigger missing/bypassed):\n`,
     )
     for (const d of drift) {
       console.log(
@@ -140,10 +155,16 @@ async function main() {
       console.log(`             pickSetId=${d.pickSetId}`)
       if (d.liveTenth !== d.lockedTenth)
         console.log(`             tenthPlace: live=${d.liveTenth}  locked=${d.lockedTenth}`)
+      if (d.liveTenthSeatKey !== d.lockedTenthSeatKey)
+        console.log(`             tenthSeat : live=${d.liveTenthSeatKey}  locked=${d.lockedTenthSeatKey}`)
       if (d.liveWinner !== d.lockedWinner)
         console.log(`             winner    : live=${d.liveWinner}  locked=${d.lockedWinner}`)
+      if (d.liveWinnerSeatKey !== d.lockedWinnerSeatKey)
+        console.log(`             winnerSeat: live=${d.liveWinnerSeatKey}  locked=${d.lockedWinnerSeatKey}`)
       if (d.liveDnf !== d.lockedDnf)
         console.log(`             dnf       : live=${d.liveDnf}  locked=${d.lockedDnf}`)
+      if (d.liveDnfSeatKey !== d.lockedDnfSeatKey)
+        console.log(`             dnfSeat   : live=${d.liveDnfSeatKey}  locked=${d.lockedDnfSeatKey}`)
       console.log()
     }
   }


### PR DESCRIPTION
## Summary
- extend the post-lock drift diagnostic to select live and locked seat-key snapshots
- compare driver and seat snapshot fields with IS DISTINCT FROM for null-safe drift detection
- report seat-key-only drift in the snapshot drift output
- add a script regression test for the protected SQL fields

Closes #125

## Test Plan
- [x] node --test scripts/find-cheated-picks.test.mjs (fails before fix, passes after)
- [x] npm run test:scripts
- [x] npx tsc --noEmit
- [x] npm run lint
- [x] npm run build