### PR TITLE
Cover public leaderboard auth contract

### DIFF
--- a/src/app/api/leaderboard/get-handler.test.mjs
+++ b/src/app/api/leaderboard/get-handler.test.mjs
@@ -57,3 +57,51 @@ test("GET keeps season as the default userRank sort", async () => {
   assert.deepEqual(rankCalls, [{ userId: "user-1", seasonId: "season-1", sort: "season" }])
   assert.equal((await response.json()).userRank, 2)
 })
+
+test("GET allows unauthenticated global leaderboard reads", async () => {
+  const globalCalls = []
+  const rankCalls = []
+  const response = await handleLeaderboardGet(
+    request("http://localhost/api/leaderboard?scope=global&sort=season&seasonId=season-1"),
+    dependencies({
+      auth: async () => null,
+      mobileAuth: async () => null,
+      getGlobalLeaderboard: async (seasonId, sort, limit) => {
+        globalCalls.push({ seasonId, sort, limit })
+        return [{ userId: "user-2", rank: 1 }]
+      },
+      getUserLeaderboardRank: async (...args) => {
+        rankCalls.push(args)
+        return 1
+      },
+    }),
+  )
+
+  assert.equal(response.status, 200)
+  assert.deepEqual(globalCalls, [{ seasonId: "season-1", sort: "season", limit: 20 }])
+  assert.deepEqual(rankCalls, [])
+  assert.deepEqual(await response.json(), {
+    rows: [{ userId: "user-2", rank: 1 }],
+    userRank: null,
+    userRow: null,
+  })
+})
+
+test("GET requires authentication for friends leaderboard reads", async () => {
+  const friendsCalls = []
+  const response = await handleLeaderboardGet(
+    request("http://localhost/api/leaderboard?scope=friends&sort=season&seasonId=season-1"),
+    dependencies({
+      auth: async () => null,
+      mobileAuth: async () => null,
+      getFriendsLeaderboard: async (...args) => {
+        friendsCalls.push(args)
+        return []
+      },
+    }),
+  )
+
+  assert.equal(response.status, 401)
+  assert.deepEqual(friendsCalls, [])
+  assert.deepEqual(await response.json(), { error: "Unauthorized" })
+})


### PR DESCRIPTION
## Summary
- add regression coverage that unauthenticated global leaderboard reads return rows with null personalization
- add regression coverage that unauthenticated friends-scope reads still return 401

Closes #126

## Test Plan
- [x] node --test src/app/api/leaderboard/get-handler.test.mjs
- [x] npm run test:routes
- [x] npx tsc --noEmit
- [x] npm run lint
- [x] npm run build

## Notes
- The implementation already matched the intended contract on main; this PR adds the missing coverage and closes the stale issue.