### PR TITLE
Preserve qualifying start in race detail

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "test:routes": "node --test src/app/api/account/delete-handler.test.mjs src/app/api/users/username/post-handler.test.mjs src/app/api/picks/post-handler.test.mjs src/app/api/leaderboard/get-handler.test.mjs src/app/api/cron/sync-schedule/driver-fetch.test.mjs",
     "test:scripts": "node --test scripts/find-cheated-picks.test.mjs",
+    "test:services": "node --test src/lib/services/race.service.test.mjs",
     "lint": "next lint",
     "db:push": "prisma db push",
     "db:studio": "prisma studio",

--- a/src/lib/services/race.service.test.mjs
+++ b/src/lib/services/race.service.test.mjs
@@ -1,0 +1,14 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const source = await readFile(new URL("./race.service.ts", import.meta.url), "utf8")
+const getRaceByIdBody = source.match(
+  /export async function getRaceById[\s\S]*?const race = await db\.race\.findUnique\(\{([\s\S]*?)\n  \}\)/,
+)?.[1]
+
+assert.ok(getRaceByIdBody, "expected to find getRaceById findUnique query")
+
+test("getRaceById selects qualifyingStartUtc for race detail serialization", () => {
+  assert.match(getRaceByIdBody, /qualifyingStartUtc:\s*true/)
+})

--- a/src/lib/services/race.service.ts
+++ b/src/lib/services/race.service.ts
@@ -156,6 +156,7 @@ export async function getRaceById(
       scheduledStartUtc: true,
       lockCutoffUtc: true,
       status: true,
+      qualifyingStartUtc: true,
     },
   })
 


### PR DESCRIPTION
## Summary
- include qualifyingStartUtc in getRaceById's Prisma select so race detail serialization can return the stored value
- add service-level regression coverage for the race detail select contract

Closes #127

## Test Plan
- [x] node --test src/lib/services/race.service.test.mjs (fails before fix, passes after)
- [x] npm run test:services
- [x] npx tsc --noEmit
- [x] npm run lint
- [x] npm run build