### PR TITLE
Reset race detail load state

### DIFF
--- a/ios/FXRacing/Features/Races/RaceDetailViewModel.swift
+++ b/ios/FXRacing/Features/Races/RaceDetailViewModel.swift
@@ -59,6 +59,13 @@ final class RaceDetailViewModel {
             return
         }
 
+        errorMessage = nil
+        serverPick = nil
+        isLocalOnly = false
+        selectedWinner = nil
+        selectedP10 = nil
+        selectedDNF = nil
+
         // Populate selections: server pick takes precedence over local pick
         if let token {
             do {


### PR DESCRIPTION
## Summary
- clear stale race-detail error state after a successful detail reload
- reset server/local pick state and selected slots before hydrating the current server or local pick
- preserve the existing detail-load failure path so retry UI still receives errorMessage

Closes #129

## Test Plan
- [x] cd ios && xcodebuild -project FXRacing.xcodeproj -scheme FXRacing -destination 'generic/platform=iOS Simulator' build

## Notes
- The iOS project currently has no test target, so this is verified by build rather than an automated RaceDetailViewModel unit test.