### PR TITLE
Guard lock-picks status promotion

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "prisma generate && next build",
     "start": "next start",
-    "test:routes": "node --test src/app/api/account/delete-handler.test.mjs src/app/api/users/username/post-handler.test.mjs src/app/api/picks/post-handler.test.mjs src/app/api/leaderboard/get-handler.test.mjs src/app/api/cron/sync-schedule/driver-fetch.test.mjs",
+    "test:routes": "node --test src/app/api/account/delete-handler.test.mjs src/app/api/users/username/post-handler.test.mjs src/app/api/picks/post-handler.test.mjs src/app/api/leaderboard/get-handler.test.mjs src/app/api/cron/sync-schedule/driver-fetch.test.mjs src/app/api/cron/lock-picks/route.test.mjs",
     "test:scripts": "node --test scripts/find-cheated-picks.test.mjs",
     "test:services": "node --test src/lib/services/race.service.test.mjs",
     "lint": "next lint",

--- a/src/app/api/cron/lock-picks/route.test.mjs
+++ b/src/app/api/cron/lock-picks/route.test.mjs
@@ -1,0 +1,11 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const source = await readFile(new URL("./route.ts", import.meta.url), "utf8")
+
+test("lock-picks promotes races to LIVE with a compare-and-set status guard", () => {
+  assert.match(source, /db\.race\.updateMany\(\{/)
+  assert.match(source, /where:\s*\{\s*id:\s*race\.id,\s*status:\s*"UPCOMING"\s*\}/s)
+  assert.match(source, /data:\s*\{\s*status:\s*newStatus\s*\}/s)
+})

--- a/src/app/api/cron/lock-picks/route.ts
+++ b/src/app/api/cron/lock-picks/route.ts
@@ -76,8 +76,8 @@ export async function POST(req: NextRequest) {
         : undefined
 
     if (newStatus) {
-      await db.race.update({
-        where: { id: race.id },
+      await db.race.updateMany({
+        where: { id: race.id, status: "UPCOMING" },
         data: { status: newStatus },
       })
     }


### PR DESCRIPTION
## Summary
- change lock-picks status promotion to a compare-and-set updateMany guarded by status: "UPCOMING"
- prevent a concurrent COMPLETED or CANCELLED transition from being overwritten back to LIVE
- add route regression coverage for the guarded update shape

Closes #130

## Test Plan
- [x] node --test src/app/api/cron/lock-picks/route.test.mjs (fails before fix, passes after)
- [x] npm run test:routes
- [x] npx tsc --noEmit
- [x] npm run lint
- [x] npm run build