### PR TITLE
Use next-second session revoke cutoff

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "prisma generate && next build",
     "start": "next start",
     "test:routes": "node --test src/app/api/account/delete-handler.test.mjs src/app/api/users/username/post-handler.test.mjs src/app/api/picks/post-handler.test.mjs src/app/api/leaderboard/get-handler.test.mjs src/app/api/cron/sync-schedule/driver-fetch.test.mjs src/app/api/cron/lock-picks/route.test.mjs",
+    "test:auth": "node --test src/lib/auth/session-cutoff.test.mjs",
     "test:scripts": "node --test scripts/find-cheated-picks.test.mjs",
     "test:services": "node --test src/lib/services/race.service.test.mjs",
     "lint": "next lint",

--- a/src/lib/auth/session-cutoff.d.ts
+++ b/src/lib/auth/session-cutoff.d.ts
@@ -1,0 +1,1 @@
+export function nextSessionRevocationCutoff(now?: Date): Date

--- a/src/lib/auth/session-cutoff.js
+++ b/src/lib/auth/session-cutoff.js
@@ -1,0 +1,3 @@
+export function nextSessionRevocationCutoff(now = new Date()) {
+  return new Date((Math.floor(now.getTime() / 1000) + 1) * 1000)
+}

--- a/src/lib/auth/session-cutoff.test.mjs
+++ b/src/lib/auth/session-cutoff.test.mjs
@@ -1,0 +1,15 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+
+import { nextSessionRevocationCutoff } from "./session-cutoff.js"
+
+test("nextSessionRevocationCutoff stores the next whole-second cutoff", () => {
+  assert.equal(
+    nextSessionRevocationCutoff(new Date("2026-06-19T12:00:00.000Z")).toISOString(),
+    "2026-06-19T12:00:01.000Z",
+  )
+  assert.equal(
+    nextSessionRevocationCutoff(new Date("2026-06-19T12:00:00.999Z")).toISOString(),
+    "2026-06-19T12:00:01.000Z",
+  )
+})

--- a/src/lib/services/user.service.ts
+++ b/src/lib/services/user.service.ts
@@ -3,6 +3,7 @@
  */
 
 import { db } from '@/lib/db/client'
+import { nextSessionRevocationCutoff } from '@/lib/auth/session-cutoff'
 import { TEAMS } from '@/lib/f1/teams'
 import type { TeamSlug } from '@/lib/f1/teams'
 
@@ -273,7 +274,7 @@ export async function deleteUser(userId: string): Promise<void> {
 export async function revokeUserSessions(userId: string): Promise<Date> {
   const user = await db.user.update({
     where: { id: userId },
-    data: { sessionValidAfter: new Date() },
+    data: { sessionValidAfter: nextSessionRevocationCutoff() },
     select: { sessionValidAfter: true },
   })
 


### PR DESCRIPTION
## Summary
- store revocation cutoffs at the next whole second so same-second token iat values compare as older
- keep the existing auth/mobileAuth cutoff comparison behavior for freshly-created sessions
- add auth regression coverage for the next-second cutoff helper

Closes #131

## Test Plan
- [x] node --test src/lib/auth/session-cutoff.test.mjs (fails before helper/fix, passes after)
- [x] npm run test:auth
- [x] npx tsc --noEmit
- [x] npm run lint
- [x] npm run build