### PR TITLE
Expose segmented control selected state

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "test:routes": "node --test src/app/api/account/delete-handler.test.mjs src/app/api/users/username/post-handler.test.mjs src/app/api/picks/post-handler.test.mjs src/app/api/leaderboard/get-handler.test.mjs src/app/api/cron/sync-schedule/driver-fetch.test.mjs src/app/api/cron/lock-picks/route.test.mjs",
     "test:auth": "node --test src/lib/auth/session-cutoff.test.mjs",
+    "test:components": "node --test src/components/ui/segmented-control.test.mjs",
     "test:scripts": "node --test scripts/find-cheated-picks.test.mjs",
     "test:services": "node --test src/lib/services/race.service.test.mjs",
     "lint": "next lint",

--- a/src/components/ui/segmented-control.test.mjs
+++ b/src/components/ui/segmented-control.test.mjs
@@ -1,0 +1,10 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const source = await readFile(new URL("./segmented-control.tsx", import.meta.url), "utf8")
+
+test("SegmentedControl exposes selected button state to assistive technology", () => {
+  assert.match(source, /role="group"/)
+  assert.match(source, /aria-pressed=\{isActive\}/)
+})

--- a/src/components/ui/segmented-control.tsx
+++ b/src/components/ui/segmented-control.tsx
@@ -37,6 +37,7 @@ export function SegmentedControl({
           <button
             key={opt.value}
             type="button"
+            aria-pressed={isActive}
             onClick={() => onChange(opt.value)}
             className={cn(
               'relative flex-1 py-1.5 text-sm font-medium rounded-full transition-colors duration-150',


### PR DESCRIPTION
## Summary
- add aria-pressed to segmented-control buttons so the active segment exposes selected state to assistive technology
- add focused component contract coverage for the selected-state attribute

Closes #132

## Test Plan
- [x] node --test src/components/ui/segmented-control.test.mjs (fails before fix, passes after)
- [x] npm run test:components
- [x] npx tsc --noEmit
- [x] npm run lint
- [x] npm run build

## Notes
- The repo does not currently have React Testing Library installed, so the regression is a source-level contract test rather than a DOM accessibility test.