### PR TITLE
Encode race sign-in callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test:routes": "node --test src/app/api/account/delete-handler.test.mjs src/app/api/users/username/post-handler.test.mjs src/app/api/picks/post-handler.test.mjs src/app/api/leaderboard/get-handler.test.mjs src/app/api/cron/sync-schedule/driver-fetch.test.mjs src/app/api/cron/lock-picks/route.test.mjs",
     "test:auth": "node --test src/lib/auth/session-cutoff.test.mjs",
     "test:components": "node --test src/components/ui/segmented-control.test.mjs",
+    "test:pages": "node --test 'src/app/(main)/races/race-detail-page.test.mjs'",
     "test:scripts": "node --test scripts/find-cheated-picks.test.mjs",
     "test:services": "node --test src/lib/services/race.service.test.mjs",
     "lint": "next lint",

--- a/src/app/(main)/races/[raceId]/page.tsx
+++ b/src/app/(main)/races/[raceId]/page.tsx
@@ -115,6 +115,7 @@ export default async function RacePickPage({
 
   const showResults =
     race.status === RaceStatus.COMPLETED || existingPick?.scoreBreakdown != null
+  const signInHref = `/signin?callbackUrl=${encodeURIComponent(`/races/${params.raceId}`)}`
 
   return (
     <div className="px-4 pt-3 pb-6 flex flex-col gap-4">
@@ -146,7 +147,7 @@ export default async function RacePickPage({
             <div className="rounded-2xl bg-surface border border-[var(--border)] p-4 text-center">
               <p className="text-sm text-text-secondary mb-3">Sign in to see your picks and score</p>
               <Link
-                href={`/signin?callbackUrl=/races/${params.raceId}`}
+                href={signInHref}
                 className="inline-flex items-center justify-center rounded-xl bg-accent text-white text-sm font-semibold px-5 py-2.5"
               >
                 Sign in

--- a/src/app/(main)/races/race-detail-page.test.mjs
+++ b/src/app/(main)/races/race-detail-page.test.mjs
@@ -1,0 +1,10 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const source = await readFile(new URL("./[raceId]/page.tsx", import.meta.url), "utf8")
+
+test("race detail sign-in callback URL encodes the dynamic race id path", () => {
+  assert.match(source, /encodeURIComponent\(`\/races\/\$\{params\.raceId\}`\)/)
+  assert.doesNotMatch(source, /href=\{`\/signin\?callbackUrl=\/races\/\$\{params\.raceId\}`\}/)
+})


### PR DESCRIPTION
## Summary
- encode the race detail callback path before placing it in the sign-in query string
- add page-source regression coverage for dynamic raceId callback encoding

Closes #133

## Test Plan
- [x] node --test src/app/(main)/races/race-detail-page.test.mjs (fails before fix, passes after)
- [x] npm run test:pages
- [x] npx tsc --noEmit
- [x] npm run lint
- [x] npm run build