### PR TITLE
Guard stale profile async responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "test:routes": "node --test src/app/api/account/delete-handler.test.mjs src/app/api/users/username/post-handler.test.mjs src/app/api/picks/post-handler.test.mjs src/app/api/leaderboard/get-handler.test.mjs src/app/api/cron/sync-schedule/driver-fetch.test.mjs src/app/api/cron/lock-picks/route.test.mjs",
     "test:auth": "node --test src/lib/auth/session-cutoff.test.mjs",
-    "test:components": "node --test src/components/ui/segmented-control.test.mjs",
+    "test:components": "node --test src/components/ui/segmented-control.test.mjs 'src/app/(main)/profile/profile-async-guards.test.mjs'",
     "test:pages": "node --test 'src/app/(main)/races/race-detail-page.test.mjs'",
     "test:scripts": "node --test scripts/find-cheated-picks.test.mjs",
     "test:services": "node --test src/lib/services/race.service.test.mjs",

--- a/src/app/(main)/profile/TeamPicker.tsx
+++ b/src/app/(main)/profile/TeamPicker.tsx
@@ -13,9 +13,12 @@ interface TeamPickerProps {
 export function TeamPicker({ teams, initialSlug }: TeamPickerProps) {
   const [selected, setSelected] = React.useState<string | null>(initialSlug)
   const [status, setStatus] = React.useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
+  const saveRequestRef = React.useRef(0)
 
   async function pick(slug: string | null) {
+    const previous = selected
     const next = selected === slug ? null : slug
+    const requestId = ++saveRequestRef.current
     setSelected(next)
     setStatus('saving')
 
@@ -26,12 +29,18 @@ export function TeamPicker({ teams, initialSlug }: TeamPickerProps) {
         body: JSON.stringify({ slug: next }),
       })
       if (!res.ok) throw new Error()
+      if (saveRequestRef.current !== requestId) return
       setStatus('saved')
-      setTimeout(() => setStatus('idle'), 1500)
+      setTimeout(() => {
+        if (saveRequestRef.current === requestId) setStatus('idle')
+      }, 1500)
     } catch {
-      setSelected(selected) // revert
+      if (saveRequestRef.current !== requestId) return
+      setSelected(previous)
       setStatus('error')
-      setTimeout(() => setStatus('idle'), 2000)
+      setTimeout(() => {
+        if (saveRequestRef.current === requestId) setStatus('idle')
+      }, 2000)
     }
   }
 

--- a/src/app/(main)/profile/UsernameChangeForm.tsx
+++ b/src/app/(main)/profile/UsernameChangeForm.tsx
@@ -20,9 +20,11 @@ export function UsernameChangeForm({ currentUsername }: { currentUsername: strin
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [done, setDone] = useState(false)
   const debounce = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const availabilityRequestRef = useRef(0)
 
   const checkAvailability = useCallback((value: string) => {
     if (debounce.current) clearTimeout(debounce.current)
+    const requestId = ++availabilityRequestRef.current
     const fmt = validateUsername(value)
     if (fmt || !value) { setIsAvailable(null); setIsChecking(false); return }
     setIsChecking(true)
@@ -30,14 +32,16 @@ export function UsernameChangeForm({ currentUsername }: { currentUsername: strin
       try {
         const res = await fetch(`/api/users/username?username=${encodeURIComponent(value)}`)
         const data: { available: boolean } = await res.json()
+        if (availabilityRequestRef.current !== requestId) return
         setIsAvailable(data.available)
         if (!data.available) setError('Username already taken.')
         else setError(null)
       } catch {
+        if (availabilityRequestRef.current !== requestId) return
         setIsAvailable(null)
         setError("Couldn't verify username. Please try again.")
       } finally {
-        setIsChecking(false)
+        if (availabilityRequestRef.current === requestId) setIsChecking(false)
       }
     }, 400)
   }, [])

--- a/src/app/(main)/profile/UsernameSetForm.tsx
+++ b/src/app/(main)/profile/UsernameSetForm.tsx
@@ -20,9 +20,11 @@ export function UsernameSetForm() {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [done, setDone] = useState(false)
   const debounce = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const availabilityRequestRef = useRef(0)
 
   const checkAvailability = useCallback((value: string) => {
     if (debounce.current) clearTimeout(debounce.current)
+    const requestId = ++availabilityRequestRef.current
     const fmt = validateUsername(value)
     if (fmt || !value) { setIsAvailable(null); setIsChecking(false); return }
     setIsChecking(true)
@@ -30,14 +32,16 @@ export function UsernameSetForm() {
       try {
         const res = await fetch(`/api/users/username?username=${encodeURIComponent(value)}`)
         const data: { available: boolean } = await res.json()
+        if (availabilityRequestRef.current !== requestId) return
         setIsAvailable(data.available)
         if (!data.available) setError('Username already taken.')
         else setError(null)
       } catch {
+        if (availabilityRequestRef.current !== requestId) return
         setIsAvailable(null)
         setError("Couldn't verify username. Please try again.")
       } finally {
-        setIsChecking(false)
+        if (availabilityRequestRef.current === requestId) setIsChecking(false)
       }
     }, 400)
   }, [])

--- a/src/app/(main)/profile/profile-async-guards.test.mjs
+++ b/src/app/(main)/profile/profile-async-guards.test.mjs
@@ -1,0 +1,24 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+async function source(path) {
+  return readFile(new URL(path, import.meta.url), "utf8")
+}
+
+test("username availability checks ignore stale async responses", async () => {
+  for (const path of ["./UsernameSetForm.tsx", "./UsernameChangeForm.tsx"]) {
+    const text = await source(path)
+    assert.match(text, /availabilityRequestRef = useRef\(0\)/)
+    assert.match(text, /const requestId = \+\+availabilityRequestRef\.current/)
+    assert.match(text, /availabilityRequestRef\.current !== requestId/)
+  }
+})
+
+test("team picker ignores stale async save responses", async () => {
+  const text = await source("./TeamPicker.tsx")
+  assert.match(text, /saveRequestRef = React\.useRef\(0\)/)
+  assert.match(text, /const requestId = \+\+saveRequestRef\.current/)
+  assert.match(text, /saveRequestRef\.current !== requestId/)
+  assert.doesNotMatch(text, /setSelected\(selected\) \/\/ revert/)
+})


### PR DESCRIPTION
Closes #134

## Summary
- ignore stale username availability responses in both profile username forms
- ignore stale team-picker save responses and only revert the latest failed request
- add focused component regression coverage for the async guards

## Test Plan
- [x] `node --test 'src/app/(main)/profile/profile-async-guards.test.mjs'`\n- [x] `npm run test:components`\n- [x] `npx tsc --noEmit`\n- [x] `npm run lint`\n- [x] `npm run build`\n\n— gib