### PR TITLE
Guard stale onboarding username checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test:routes": "node --test src/app/api/account/delete-handler.test.mjs src/app/api/users/username/post-handler.test.mjs src/app/api/picks/post-handler.test.mjs src/app/api/leaderboard/get-handler.test.mjs src/app/api/cron/sync-schedule/driver-fetch.test.mjs src/app/api/cron/lock-picks/route.test.mjs",
     "test:auth": "node --test src/lib/auth/session-cutoff.test.mjs",
     "test:components": "node --test src/components/ui/segmented-control.test.mjs 'src/app/(main)/profile/profile-async-guards.test.mjs'",
-    "test:pages": "node --test 'src/app/(main)/races/race-detail-page.test.mjs'",
+    "test:pages": "node --test 'src/app/(main)/races/race-detail-page.test.mjs' 'src/app/(auth)/onboarding/username/page.test.mjs'",
     "test:scripts": "node --test scripts/find-cheated-picks.test.mjs",
     "test:services": "node --test src/lib/services/race.service.test.mjs",
     "lint": "next lint",

--- a/src/app/(auth)/onboarding/username/page.test.mjs
+++ b/src/app/(auth)/onboarding/username/page.test.mjs
@@ -1,0 +1,12 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const page = await readFile(new URL("./page.tsx", import.meta.url), "utf8")
+
+test("onboarding username availability ignores stale async responses", () => {
+  assert.match(page, /availabilityRequestRef = useRef\(0\)/)
+  assert.match(page, /const requestId = \+\+availabilityRequestRef\.current/)
+  assert.match(page, /availabilityRequestRef\.current !== requestId/)
+  assert.match(page, /availabilityRequestRef\.current === requestId/)
+})

--- a/src/app/(auth)/onboarding/username/page.tsx
+++ b/src/app/(auth)/onboarding/username/page.tsx
@@ -42,6 +42,7 @@ export default function UsernameOnboardingPage() {
 
   // Ref to cancel stale availability checks
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const availabilityRequestRef = useRef(0)
 
   // Fetch suggestions once on mount
   useEffect(() => {
@@ -56,6 +57,7 @@ export default function UsernameOnboardingPage() {
   // Debounced availability check: fires 400ms after the user stops typing
   const checkAvailability = useCallback((value: string) => {
     if (debounceTimer.current) clearTimeout(debounceTimer.current)
+    const requestId = ++availabilityRequestRef.current
 
     const formatError = validateUsername(value)
     if (formatError || value.length === 0) {
@@ -71,6 +73,7 @@ export default function UsernameOnboardingPage() {
           `/api/users/username?username=${encodeURIComponent(value)}`,
         )
         const data: { available: boolean } = await res.json()
+        if (availabilityRequestRef.current !== requestId) return
         setIsAvailable(data.available)
         if (!data.available) {
           setError("Username already taken.")
@@ -78,10 +81,11 @@ export default function UsernameOnboardingPage() {
           setError(null)
         }
       } catch {
+        if (availabilityRequestRef.current !== requestId) return
         setIsAvailable(null)
         setError("Couldn't verify username. Please try again.")
       } finally {
-        setIsChecking(false)
+        if (availabilityRequestRef.current === requestId) setIsChecking(false)
       }
     }, 400)
   }, [])


### PR DESCRIPTION
Closes #135

## Summary
- add a request sequence guard to onboarding username availability checks
- ignore stale success/error/finally updates from older in-flight checks
- add a focused page regression test and include it in `npm run test:pages`

## Test Plan
- [x] `node --test 'src/app/(auth)/onboarding/username/page.test.mjs'`\n- [x] `npm run test:pages`\n- [x] `npx tsc --noEmit`\n- [x] `npm run lint`\n- [x] `npm run build`\n\n— gib