### PR TITLE
Skip cancelled races in sync entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "prisma generate && next build",
     "start": "next start",
-    "test:routes": "node --test src/app/api/account/delete-handler.test.mjs src/app/api/users/username/post-handler.test.mjs src/app/api/picks/post-handler.test.mjs src/app/api/leaderboard/get-handler.test.mjs src/app/api/cron/sync-schedule/driver-fetch.test.mjs src/app/api/cron/lock-picks/route.test.mjs",
+    "test:routes": "node --test src/app/api/account/delete-handler.test.mjs src/app/api/users/username/post-handler.test.mjs src/app/api/picks/post-handler.test.mjs src/app/api/leaderboard/get-handler.test.mjs src/app/api/cron/sync-schedule/driver-fetch.test.mjs src/app/api/cron/lock-picks/route.test.mjs src/app/api/cron/sync-entries/route.test.mjs",
     "test:auth": "node --test src/lib/auth/session-cutoff.test.mjs",
     "test:components": "node --test src/components/ui/segmented-control.test.mjs 'src/app/(main)/profile/profile-async-guards.test.mjs'",
     "test:pages": "node --test 'src/app/(main)/races/race-detail-page.test.mjs' 'src/app/(auth)/onboarding/username/page.test.mjs'",

--- a/src/app/api/cron/sync-entries/route.test.mjs
+++ b/src/app/api/cron/sync-entries/route.test.mjs
@@ -1,0 +1,10 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const route = await readFile(new URL("./route.ts", import.meta.url), "utf8")
+
+test("sync-entries only selects race statuses whose grids can still change", () => {
+  assert.match(route, /status:\s*\{\s*in:\s*\[\s*'UPCOMING',\s*'LIVE'\s*\]/s)
+  assert.doesNotMatch(route, /status:\s*\{\s*not:\s*'COMPLETED'\s*\}/)
+})

--- a/src/app/api/cron/sync-entries/route.ts
+++ b/src/app/api/cron/sync-entries/route.ts
@@ -2,7 +2,7 @@
  * Cron: lightweight refresh of RaceEntry rows for upcoming races.
  *
  * Unlike sync-schedule (which fetches all sessions and meetings for the year),
- * this route only touches races that are not yet completed — using the
+ * this route only touches upcoming/live races — using the
  * openf1SessionKey already stored in the Race record to fetch current drivers.
  *
  * Safe to run hourly. Handles mid-season driver swaps and substitutes.
@@ -33,11 +33,11 @@ export async function POST(req: NextRequest) {
 
   const provider = createF1Provider()
 
-  // Only process races that are not yet completed and have a known OpenF1 session key.
+  // Only process races whose entry lists can still change and have a known OpenF1 session key.
   // LIVE races are included so the entry list stays accurate right up to race start.
   const upcomingRaces = await db.race.findMany({
     where: {
-      status: { not: 'COMPLETED' },
+      status: { in: ['UPCOMING', 'LIVE'] },
       openf1SessionKey: { not: null },
     },
     select: {


### PR DESCRIPTION
Closes #137

## Summary
- restrict sync-entries race selection to `UPCOMING` and `LIVE` statuses
- keep cancelled/completed race grids out of the refresh path
- add a route regression check and include it in `npm run test:routes`

## Test Plan
- [x] `node --test src/app/api/cron/sync-entries/route.test.mjs`
- [x] `npm run test:routes`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

— gib