### PR TITLE
Encrypt token filter object values

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "test:routes": "node --test src/app/api/account/delete-handler.test.mjs src/app/api/users/username/post-handler.test.mjs src/app/api/picks/post-handler.test.mjs src/app/api/leaderboard/get-handler.test.mjs src/app/api/cron/sync-schedule/driver-fetch.test.mjs src/app/api/cron/lock-picks/route.test.mjs src/app/api/cron/sync-entries/route.test.mjs",
     "test:auth": "node --test src/lib/auth/session-cutoff.test.mjs",
+    "test:db": "node --test src/lib/db/token-field-transform.test.mjs",
     "test:components": "node --test src/components/ui/segmented-control.test.mjs 'src/app/(main)/profile/profile-async-guards.test.mjs'",
     "test:pages": "node --test 'src/app/(main)/races/race-detail-page.test.mjs' 'src/app/(auth)/onboarding/username/page.test.mjs'",
     "test:scripts": "node --test scripts/find-cheated-picks.test.mjs",

--- a/src/lib/db/client.ts
+++ b/src/lib/db/client.ts
@@ -3,6 +3,7 @@ import {
   decryptTokenValue,
   encryptTokenValue,
 } from "@/lib/security/account-token-crypto";
+import { transformTokenFields } from "@/lib/db/token-field-transform";
 
 // Extend the global type to hold the cached client in dev.
 // This prevents multiple PrismaClient instances from being created
@@ -10,54 +11,6 @@ import {
 declare global {
   // eslint-disable-next-line no-var
   var __prisma: PrismaClient | undefined;
-}
-
-const TOKEN_FIELDS = new Set(["access_token", "refresh_token", "id_token"]);
-
-function transformTokenFields(
-  value: unknown,
-  transform: (token: string) => string,
-): unknown {
-  if (Array.isArray(value)) {
-    return value.map((entry) => transformTokenFields(entry, transform));
-  }
-
-  if (value instanceof Date || Buffer.isBuffer(value)) {
-    return value;
-  }
-
-  if (!value || typeof value !== "object") {
-    return value;
-  }
-
-  const record = value as Record<string, unknown>;
-  const nextRecord: Record<string, unknown> = {};
-
-  for (const [key, raw] of Object.entries(record)) {
-    if (TOKEN_FIELDS.has(key)) {
-      if (typeof raw === "string") {
-        nextRecord[key] = transform(raw);
-        continue;
-      }
-
-      if (
-        raw &&
-        typeof raw === "object" &&
-        "set" in raw &&
-        typeof (raw as { set?: unknown }).set === "string"
-      ) {
-        nextRecord[key] = {
-          ...(raw as Record<string, unknown>),
-          set: transform((raw as { set: string }).set),
-        };
-        continue;
-      }
-    }
-
-    nextRecord[key] = transformTokenFields(raw, transform);
-  }
-
-  return nextRecord;
 }
 
 function createPrismaClient(): PrismaClient {

--- a/src/lib/db/token-field-transform.js
+++ b/src/lib/db/token-field-transform.js
@@ -1,0 +1,70 @@
+const TOKEN_FIELDS = new Set(["access_token", "refresh_token", "id_token"])
+const TOKEN_STRING_OPERATORS = new Set(["equals", "not", "set"])
+const TOKEN_STRING_ARRAY_OPERATORS = new Set(["in", "notIn"])
+
+function transformTokenFieldValue(value, transform) {
+  if (typeof value === "string") {
+    return transform(value)
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) =>
+      typeof entry === "string" ? transform(entry) : entry,
+    )
+  }
+
+  if (value instanceof Date || Buffer.isBuffer(value)) {
+    return value
+  }
+
+  if (!value || typeof value !== "object") {
+    return value
+  }
+
+  const nextRecord = {}
+
+  for (const [key, raw] of Object.entries(value)) {
+    if (TOKEN_STRING_OPERATORS.has(key)) {
+      nextRecord[key] = transformTokenFieldValue(raw, transform)
+      continue
+    }
+
+    if (TOKEN_STRING_ARRAY_OPERATORS.has(key)) {
+      nextRecord[key] = Array.isArray(raw)
+        ? raw.map((entry) => (typeof entry === "string" ? transform(entry) : entry))
+        : raw
+      continue
+    }
+
+    nextRecord[key] = raw
+  }
+
+  return nextRecord
+}
+
+export function transformTokenFields(value, transform) {
+  if (Array.isArray(value)) {
+    return value.map((entry) => transformTokenFields(entry, transform))
+  }
+
+  if (value instanceof Date || Buffer.isBuffer(value)) {
+    return value
+  }
+
+  if (!value || typeof value !== "object") {
+    return value
+  }
+
+  const nextRecord = {}
+
+  for (const [key, raw] of Object.entries(value)) {
+    if (TOKEN_FIELDS.has(key)) {
+      nextRecord[key] = transformTokenFieldValue(raw, transform)
+      continue
+    }
+
+    nextRecord[key] = transformTokenFields(raw, transform)
+  }
+
+  return nextRecord
+}

--- a/src/lib/db/token-field-transform.test.mjs
+++ b/src/lib/db/token-field-transform.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { transformTokenFields } from "./token-field-transform.js"
+
+const encrypt = (value) => `enc(${value})`
+
+test("transformTokenFields encrypts token string filter objects", () => {
+  const transformed = transformTokenFields(
+    {
+      where: {
+        OR: [
+          { access_token: "direct-access" },
+          {
+            access_token: {
+              equals: "access-1",
+              in: ["access-2", "access-3"],
+              notIn: ["access-4"],
+              not: { equals: "access-5" },
+              mode: "insensitive",
+            },
+          },
+        ],
+        refresh_token: { not: "refresh-1" },
+        id_token: { set: "id-1" },
+      },
+    },
+    encrypt,
+  )
+
+  assert.deepEqual(transformed, {
+    where: {
+      OR: [
+        { access_token: "enc(direct-access)" },
+        {
+          access_token: {
+            equals: "enc(access-1)",
+            in: ["enc(access-2)", "enc(access-3)"],
+            notIn: ["enc(access-4)"],
+            not: { equals: "enc(access-5)" },
+            mode: "insensitive",
+          },
+        },
+      ],
+      refresh_token: { not: "enc(refresh-1)" },
+      id_token: { set: "enc(id-1)" },
+    },
+  })
+})


### PR DESCRIPTION
Closes #138

## Summary
- move token-field transformation into a pure helper module
- encrypt supported Prisma token string filter operators: direct equality, `equals`, `in`, `notIn`, nested `not`, and update `set`
- add focused DB transform regression coverage

## Test Plan
- [x] `npm run test:db`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

— gib