### PR TITLE
Sanitize friend request update failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "prisma generate && next build",
     "start": "next start",
-    "test:routes": "node --test src/app/api/account/delete-handler.test.mjs src/app/api/users/username/post-handler.test.mjs src/app/api/picks/post-handler.test.mjs src/app/api/leaderboard/get-handler.test.mjs src/app/api/cron/sync-schedule/driver-fetch.test.mjs src/app/api/cron/lock-picks/route.test.mjs src/app/api/cron/sync-entries/route.test.mjs",
+    "test:routes": "node --test src/app/api/account/delete-handler.test.mjs src/app/api/users/username/post-handler.test.mjs src/app/api/picks/post-handler.test.mjs src/app/api/leaderboard/get-handler.test.mjs src/app/api/friends/patch-handler.test.mjs src/app/api/cron/sync-schedule/driver-fetch.test.mjs src/app/api/cron/lock-picks/route.test.mjs src/app/api/cron/sync-entries/route.test.mjs",
     "test:auth": "node --test src/lib/auth/session-cutoff.test.mjs",
     "test:db": "node --test src/lib/db/token-field-transform.test.mjs",
     "test:components": "node --test src/components/ui/segmented-control.test.mjs 'src/app/(main)/profile/profile-async-guards.test.mjs' src/components/picks/PickHero.test.mjs",

--- a/src/app/api/friends/[id]/patch-handler.js
+++ b/src/app/api/friends/[id]/patch-handler.js
@@ -1,0 +1,67 @@
+const DOMAIN_ERROR_STATUSES = [
+  [/^Friend request not found:/, 404],
+  [/^Only the addressee can accept a friend request$/, 403],
+  [/^You are not a party to this friend request$/, 403],
+  [/^Friend request is already /, 400],
+  [/^Friend request is no longer pending$/, 400],
+  [/^Cannot reject an already accepted friend request$/, 400],
+]
+
+function mapDomainError(message) {
+  return DOMAIN_ERROR_STATUSES.find(([pattern]) => pattern.test(message))?.[1] ?? null
+}
+
+export async function handleFriendRequestPatch(
+  request,
+  params,
+  {
+    auth,
+    mobileAuth,
+    acceptFriendRequest,
+    rejectFriendRequest,
+    logError = console.error,
+  },
+) {
+  const session = (await auth()) ?? (await mobileAuth(request))
+  if (!session?.user?.id) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const userId = session.user.id
+  const requestId = params.id
+
+  let body
+  try {
+    body = await request.json()
+  } catch {
+    return Response.json({ error: "Invalid request body" }, { status: 400 })
+  }
+
+  if (body.action !== "accept" && body.action !== "reject") {
+    return Response.json(
+      { error: 'action must be "accept" or "reject"' },
+      { status: 400 },
+    )
+  }
+
+  try {
+    if (body.action === "accept") {
+      await acceptFriendRequest(requestId, userId)
+    } else {
+      await rejectFriendRequest(requestId, userId)
+    }
+    return Response.json({ success: true })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Failed to update request"
+    const domainStatus = mapDomainError(message)
+    if (domainStatus) {
+      return Response.json({ error: message }, { status: domainStatus })
+    }
+
+    logError("[friends/:id] Failed to update friend request", err)
+    return Response.json(
+      { error: "Failed to update friend request" },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/friends/[id]/route.ts
+++ b/src/app/api/friends/[id]/route.ts
@@ -1,46 +1,19 @@
-import { NextResponse } from 'next/server'
 import { auth } from '@/auth'
 import { mobileAuth } from '@/lib/auth/mobileAuth'
 import {
   acceptFriendRequest,
   rejectFriendRequest,
 } from '@/lib/services/friendship.service'
+import { handleFriendRequestPatch } from './patch-handler'
 
 export async function PATCH(
   request: Request,
   { params }: { params: { id: string } }
 ) {
-  const session = (await auth()) ?? (await mobileAuth(request))
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
-
-  const userId = session.user.id
-  const requestId = params.id
-
-  let body: { action?: string }
-  try {
-    body = await request.json()
-  } catch {
-    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
-  }
-
-  if (body.action !== 'accept' && body.action !== 'reject') {
-    return NextResponse.json(
-      { error: 'action must be "accept" or "reject"' },
-      { status: 400 }
-    )
-  }
-
-  try {
-    if (body.action === 'accept') {
-      await acceptFriendRequest(requestId, userId)
-    } else {
-      await rejectFriendRequest(requestId, userId)
-    }
-    return NextResponse.json({ success: true })
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to update request'
-    return NextResponse.json({ error: message }, { status: 400 })
-  }
+  return handleFriendRequestPatch(request, params, {
+    auth,
+    mobileAuth,
+    acceptFriendRequest,
+    rejectFriendRequest,
+  })
 }

--- a/src/app/api/friends/patch-handler.test.mjs
+++ b/src/app/api/friends/patch-handler.test.mjs
@@ -1,0 +1,52 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+
+import { handleFriendRequestPatch } from "./[id]/patch-handler.js"
+
+function jsonRequest(body) {
+  return new Request("http://localhost/api/friends/request-1", {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  })
+}
+
+function authedDeps(overrides = {}) {
+  return {
+    auth: async () => ({ user: { id: "user-1" } }),
+    mobileAuth: async () => null,
+    acceptFriendRequest: async () => {},
+    rejectFriendRequest: async () => {},
+    logError: () => {},
+    ...overrides,
+  }
+}
+
+test("PATCH returns a generic 500 for unexpected friendship failures", async () => {
+  const response = await handleFriendRequestPatch(
+    jsonRequest({ action: "accept" }),
+    { id: "request-1" },
+    authedDeps({
+      acceptFriendRequest: async () => {
+        throw new Error("database password leaked in raw error")
+      },
+    }),
+  )
+
+  assert.equal(response.status, 500)
+  assert.deepEqual(await response.json(), { error: "Failed to update friend request" })
+})
+
+test("PATCH preserves expected friendship domain errors as 4xx", async () => {
+  const response = await handleFriendRequestPatch(
+    jsonRequest({ action: "reject" }),
+    { id: "request-1" },
+    authedDeps({
+      rejectFriendRequest: async () => {
+        throw new Error("You are not a party to this friend request")
+      },
+    }),
+  )
+
+  assert.equal(response.status, 403)
+  assert.deepEqual(await response.json(), { error: "You are not a party to this friend request" })
+})


### PR DESCRIPTION
Closes #142

## Summary
- extract the friend-request PATCH logic into an injectable handler
- map known friendship-domain failures to 4xx responses
- log unexpected failures and return a generic 500 without leaking raw exception text
- add route regression coverage for expected and unexpected errors

## Test Plan
- [x] `node --test src/app/api/friends/patch-handler.test.mjs`
- [x] `npm run test:routes`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

— gib