### PR TITLE
Normalize leaderboard query params

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:auth": "node --test src/lib/auth/session-cutoff.test.mjs",
     "test:db": "node --test src/lib/db/token-field-transform.test.mjs",
     "test:components": "node --test src/components/ui/segmented-control.test.mjs 'src/app/(main)/profile/profile-async-guards.test.mjs' src/components/picks/PickHero.test.mjs",
-    "test:pages": "node --test 'src/app/(main)/races/race-detail-page.test.mjs' 'src/app/(auth)/onboarding/username/page.test.mjs'",
+    "test:pages": "node --test 'src/app/(main)/races/race-detail-page.test.mjs' 'src/app/(auth)/onboarding/username/page.test.mjs' 'src/app/(main)/leaderboard/search-params.test.mjs'",
     "test:scripts": "node --test scripts/find-cheated-picks.test.mjs",
     "test:services": "node --test src/lib/services/race.service.test.mjs",
     "lint": "next lint",

--- a/src/app/(main)/leaderboard/page.tsx
+++ b/src/app/(main)/leaderboard/page.tsx
@@ -7,10 +7,16 @@ import {
 } from "@/lib/services/leaderboard.service"
 import { LeaderboardList } from "@/components/leaderboard/LeaderboardList"
 import Link from "next/link"
+import {
+  normalizeLeaderboardScope,
+  normalizeLeaderboardSort,
+} from "./search-params"
+
+type LeaderboardSearchParamValue = string | string[] | undefined
 
 interface LeaderboardSearchParams {
-  scope?: string
-  sort?: string
+  scope?: LeaderboardSearchParamValue
+  sort?: LeaderboardSearchParamValue
 }
 
 export default async function LeaderboardPage({
@@ -21,10 +27,6 @@ export default async function LeaderboardPage({
   const session = await auth()
   const userId = session?.user?.id ?? null
 
-  // Guests can only see global leaderboard
-  const scope = userId && searchParams.scope === "friends" ? "friends" : "global"
-  const sort = searchParams.sort ?? "season"
-
   const season = await getActiveSeason()
   if (!season) {
     return (
@@ -34,10 +36,17 @@ export default async function LeaderboardPage({
     )
   }
 
+  // Guests can only see global leaderboard.
+  const scope = normalizeLeaderboardScope(searchParams.scope, Boolean(userId))
+
   const allRaces = await getRacesForSeason(season.id)
   const completedRaces = allRaces
     .filter((r) => r.status === "COMPLETED")
     .map((r) => ({ id: r.id, round: r.round, name: r.name, type: r.type }))
+  const sort = normalizeLeaderboardSort(
+    searchParams.sort,
+    completedRaces.map((race) => race.id),
+  )
 
   const [rows, userRank] = await Promise.all([
     scope === "friends" && userId

--- a/src/app/(main)/leaderboard/search-params.js
+++ b/src/app/(main)/leaderboard/search-params.js
@@ -1,0 +1,31 @@
+/**
+ * @param {string | string[] | undefined} value
+ * @returns {string | undefined}
+ */
+function firstSearchParamValue(value) {
+  if (Array.isArray(value)) {
+    return typeof value[0] === "string" ? value[0] : undefined
+  }
+
+  return typeof value === "string" ? value : undefined
+}
+
+/**
+ * @param {string | string[] | undefined} value
+ * @param {boolean} hasUser
+ * @returns {"global" | "friends"}
+ */
+export function normalizeLeaderboardScope(value, hasUser) {
+  return hasUser && firstSearchParamValue(value) === "friends" ? "friends" : "global"
+}
+
+/**
+ * @param {string | string[] | undefined} value
+ * @param {string[]} completedRaceIds
+ * @returns {string}
+ */
+export function normalizeLeaderboardSort(value, completedRaceIds) {
+  const sort = firstSearchParamValue(value)
+  if (sort === "season") return "season"
+  return completedRaceIds.includes(sort) ? sort : "season"
+}

--- a/src/app/(main)/leaderboard/search-params.test.mjs
+++ b/src/app/(main)/leaderboard/search-params.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  normalizeLeaderboardScope,
+  normalizeLeaderboardSort,
+} from "./search-params.js"
+
+test("normalizeLeaderboardSort defaults unsupported sort values to season", () => {
+  assert.equal(normalizeLeaderboardSort("not-a-supported-sort", ["race-1"]), "season")
+  assert.equal(normalizeLeaderboardSort("", ["race-1"]), "season")
+  assert.equal(normalizeLeaderboardSort(undefined, ["race-1"]), "season")
+})
+
+test("normalizeLeaderboardSort accepts season and completed race ids", () => {
+  assert.equal(normalizeLeaderboardSort("season", ["race-1"]), "season")
+  assert.equal(normalizeLeaderboardSort("race-1", ["race-1"]), "race-1")
+})
+
+test("normalizeLeaderboardSort uses only the first repeated query value", () => {
+  assert.equal(normalizeLeaderboardSort(["race-1", "race-2"], ["race-1", "race-2"]), "race-1")
+  assert.equal(normalizeLeaderboardSort(["bad", "race-1"], ["race-1"]), "season")
+})
+
+test("normalizeLeaderboardScope only allows friends scope for signed-in users", () => {
+  assert.equal(normalizeLeaderboardScope("friends", true), "friends")
+  assert.equal(normalizeLeaderboardScope(["friends", "global"], true), "friends")
+  assert.equal(normalizeLeaderboardScope("friends", false), "global")
+  assert.equal(normalizeLeaderboardScope("bad", true), "global")
+})


### PR DESCRIPTION
Closes #143

## Summary
- add a leaderboard query normalization helper for repeated and unsupported search params
- restrict page sort to `season` or completed race ids before service calls
- include the regression in `npm run test:pages`

## Test Plan
- [x] `node --test 'src/app/(main)/leaderboard/search-params.test.mjs'`
- [x] `npm run test:pages`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

— gib
