### PR TITLE
Guard onboarding username suggestions

### DIFF
--- a/src/app/(auth)/onboarding/username/page.test.mjs
+++ b/src/app/(auth)/onboarding/username/page.test.mjs
@@ -10,3 +10,9 @@ test("onboarding username availability ignores stale async responses", () => {
   assert.match(page, /availabilityRequestRef\.current !== requestId/)
   assert.match(page, /availabilityRequestRef\.current === requestId/)
 })
+
+test("onboarding username suggestions ignore non-success and malformed payloads", () => {
+  assert.match(page, /if \(!r\.ok\) return \[\]/)
+  assert.match(page, /Array\.isArray\(suggestions\)/)
+  assert.doesNotMatch(page, /setSuggestions\(data\.suggestions\)/)
+})

--- a/src/app/(auth)/onboarding/username/page.tsx
+++ b/src/app/(auth)/onboarding/username/page.tsx
@@ -47,8 +47,14 @@ export default function UsernameOnboardingPage() {
   // Fetch suggestions once on mount
   useEffect(() => {
     fetch("/api/users/suggest-usernames")
-      .then((r) => r.json())
-      .then((data: { suggestions: string[] }) => setSuggestions(data.suggestions))
+      .then(async (r) => {
+        if (!r.ok) return []
+
+        const data: unknown = await r.json()
+        const suggestions = (data as { suggestions?: unknown }).suggestions
+        return Array.isArray(suggestions) ? suggestions : []
+      })
+      .then(setSuggestions)
       .catch(() => {
         // Suggestions are non-critical — silently ignore network errors
       })


### PR DESCRIPTION
Closes #144

## Summary
- guard the onboarding username suggestions fetch against non-OK responses
- validate the suggestions payload shape before updating state
- extend the onboarding page regression test for malformed suggestion payloads

## Test Plan
- [x] `node --test 'src/app/(auth)/onboarding/username/page.test.mjs'`
- [x] `npm run test:pages`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

— gib
