### PR TITLE
Skip cancelled races in diagnostics lock checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "prisma generate && next build",
     "start": "next start",
-    "test:routes": "node --test src/app/api/account/delete-handler.test.mjs src/app/api/users/username/post-handler.test.mjs src/app/api/picks/post-handler.test.mjs src/app/api/leaderboard/get-handler.test.mjs src/app/api/friends/patch-handler.test.mjs src/app/api/cron/sync-schedule/driver-fetch.test.mjs src/app/api/cron/lock-picks/route.test.mjs src/app/api/cron/sync-entries/route.test.mjs",
+    "test:routes": "node --test src/app/api/account/delete-handler.test.mjs src/app/api/users/username/post-handler.test.mjs src/app/api/picks/post-handler.test.mjs src/app/api/leaderboard/get-handler.test.mjs src/app/api/friends/patch-handler.test.mjs src/app/api/cron/sync-schedule/driver-fetch.test.mjs src/app/api/cron/lock-picks/route.test.mjs src/app/api/cron/sync-entries/route.test.mjs src/app/api/diag/race/route.test.mjs",
     "test:auth": "node --test src/lib/auth/session-cutoff.test.mjs",
     "test:db": "node --test src/lib/db/token-field-transform.test.mjs",
     "test:components": "node --test src/components/ui/segmented-control.test.mjs 'src/app/(main)/profile/profile-async-guards.test.mjs' src/components/picks/PickHero.test.mjs",

--- a/src/app/api/diag/race/[id]/route.ts
+++ b/src/app/api/diag/race/[id]/route.ts
@@ -91,6 +91,7 @@ export async function GET(
   const now = new Date()
   const lockCutoffPassed = race.lockCutoffUtc <= now
   const startedScheduled = race.scheduledStartUtc <= now
+  const lockPicksOwnsRace = race.status === "UPCOMING" || race.status === "LIVE"
 
   // Heuristic mismatch flags — surface anything obviously off so the user can
   // decide which cron to re-run from their phone.
@@ -126,7 +127,7 @@ export async function GET(
     )
   }
   if (
-    race.status !== "COMPLETED" &&
+    lockPicksOwnsRace &&
     startedScheduled &&
     race.status !== "LIVE"
   ) {
@@ -135,7 +136,7 @@ export async function GET(
     )
   }
   if (
-    race.status !== "COMPLETED" &&
+    lockPicksOwnsRace &&
     lockCutoffPassed &&
     pickSetCount > 0
   ) {

--- a/src/app/api/diag/race/route.test.mjs
+++ b/src/app/api/diag/race/route.test.mjs
@@ -1,0 +1,15 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const source = await readFile(new URL("./[id]/route.ts", import.meta.url), "utf8")
+
+test("race diagnostics skip lock-picks heuristics for cancelled races", () => {
+  assert.match(
+    source,
+    /const lockPicksOwnsRace = race\.status === "UPCOMING" \|\| race\.status === "LIVE"/,
+  )
+  assert.match(source, /lockPicksOwnsRace &&\s*startedScheduled/s)
+  assert.match(source, /lockPicksOwnsRace &&\s*lockCutoffPassed/s)
+  assert.doesNotMatch(source, /race\.status !== "COMPLETED" &&\s*startedScheduled/s)
+})


### PR DESCRIPTION
Closes #146

## Summary
- limit diag race lock-picks heuristics to statuses lock-picks owns: `UPCOMING` and `LIVE`
- prevent past `CANCELLED` races with retained picks from being marked unhealthy by lock transition checks
- add route-level regression coverage for the cancelled-race diagnostic guard

## Test Plan
- [x] `node --test src/app/api/diag/race/route.test.mjs`
- [x] `npm run test:routes`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

— gib
