### PR TITLE
Guard duplicate Apple sign-in completions

### DIFF
--- a/ios/FXRacing/Features/Auth/SignInViewModel.swift
+++ b/ios/FXRacing/Features/Auth/SignInViewModel.swift
@@ -11,6 +11,10 @@ final class SignInViewModel {
         _ result: Result<ASAuthorization, Error>,
         authManager: AuthManager
     ) async {
+        guard !isLoading else {
+            return
+        }
+
         switch result {
         case .success(let authorization):
             guard

--- a/ios/signin-view-model.test.mjs
+++ b/ios/signin-view-model.test.mjs
@@ -1,0 +1,15 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const source = await readFile(
+  new URL("./FXRacing/Features/Auth/SignInViewModel.swift", import.meta.url),
+  "utf8",
+)
+
+test("SignInViewModel ignores duplicate Apple completions while loading", () => {
+  assert.match(source, /guard !isLoading else \{\s*return\s*\}/)
+  assert.ok(
+    source.indexOf("guard !isLoading else") < source.indexOf("switch result"),
+  )
+})

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:auth": "node --test src/lib/auth/session-cutoff.test.mjs",
     "test:db": "node --test src/lib/db/token-field-transform.test.mjs",
     "test:components": "node --test src/components/ui/segmented-control.test.mjs 'src/app/(main)/profile/profile-async-guards.test.mjs' src/components/picks/PickHero.test.mjs",
+    "test:ios": "node --test ios/project-signing.test.mjs ios/signin-view-model.test.mjs",
     "test:ios-config": "node --test ios/project-signing.test.mjs",
     "test:pages": "node --test 'src/app/(main)/races/race-detail-page.test.mjs' 'src/app/(auth)/onboarding/username/page.test.mjs' 'src/app/(main)/leaderboard/search-params.test.mjs'",
     "test:scripts": "node --test scripts/find-cheated-picks.test.mjs",


### PR DESCRIPTION
Closes #147

## Summary
- add an early `isLoading` guard in `SignInViewModel.handleAppleResult`
- prevent reentrant Sign in with Apple completions from starting duplicate backend sign-in calls
- add iOS source regression coverage and an aggregate `npm run test:ios` script

## Test Plan
- [x] `node --test ios/signin-view-model.test.mjs`
- [x] `npm run test:ios`
- [x] `cd ios && xcodebuild -project FXRacing.xcodeproj -scheme FXRacing -destination 'generic/platform=iOS Simulator' build`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

— gib
