### PR TITLE
Correct lock-picks cron deployment notes

### DIFF
--- a/src/app/api/cron/lock-picks/route.test.mjs
+++ b/src/app/api/cron/lock-picks/route.test.mjs
@@ -9,3 +9,9 @@ test("lock-picks promotes races to LIVE with a compare-and-set status guard", ()
   assert.match(source, /where:\s*\{\s*id:\s*race\.id,\s*status:\s*"UPCOMING"\s*\}/s)
   assert.match(source, /data:\s*\{\s*status:\s*newStatus\s*\}/s)
 })
+
+test("lock-picks deployment notes point maintainers to AWS Lambda scheduling", () => {
+  assert.match(source, /AWS Lambda/)
+  assert.doesNotMatch(source, /vercel\.json/i)
+  assert.doesNotMatch(source, /Vercel Cron/i)
+})

--- a/src/app/api/cron/lock-picks/route.ts
+++ b/src/app/api/cron/lock-picks/route.ts
@@ -1,11 +1,9 @@
 /**
  * Cron: lock picks for races that have passed their cutoff time.
  *
- * Add to vercel.json:
- * {
- *   "crons": [{ "path": "/api/cron/lock-picks", "schedule": "* * * * *" }]
- * }
- * (Run every minute to keep lock timing accurate. Adjust based on cost tolerance.)
+ * Scheduled by the external AWS Lambda cron orchestrator.
+ * Keep this route as the authenticated HTTP target for that Lambda and update
+ * the AWS schedule there when lock cadence changes.
  *
  * Protected by the CRON_SECRET environment variable.
  */


### PR DESCRIPTION
Closes #149

## Summary
- replace the stale `vercel.json` cron snippet in `lock-picks` with AWS Lambda scheduler guidance
- add a source regression to keep lock-picks deployment notes aligned with the project cron constraint

## Test Plan
- [x] `node --test src/app/api/cron/lock-picks/route.test.mjs`
- [x] `npm run test:routes`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

— gib
