### PR TITLE
Bound cron middleware path matching

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "prisma generate && next build",
     "start": "next start",
     "test:routes": "node --test src/app/api/account/delete-handler.test.mjs src/app/api/users/username/post-handler.test.mjs src/app/api/picks/post-handler.test.mjs src/app/api/leaderboard/get-handler.test.mjs src/app/api/friends/patch-handler.test.mjs src/app/api/cron/sync-schedule/driver-fetch.test.mjs src/app/api/cron/lock-picks/route.test.mjs src/app/api/cron/sync-entries/route.test.mjs src/app/api/diag/race/route.test.mjs",
-    "test:auth": "node --test src/lib/auth/session-cutoff.test.mjs",
+    "test:auth": "node --test src/lib/auth/session-cutoff.test.mjs src/lib/auth/cronPath.test.mjs",
     "test:db": "node --test src/lib/db/token-field-transform.test.mjs",
     "test:components": "node --test src/components/ui/segmented-control.test.mjs 'src/app/(main)/profile/profile-async-guards.test.mjs' src/components/picks/PickHero.test.mjs",
     "test:ios": "node --test ios/project-signing.test.mjs ios/signin-view-model.test.mjs",

--- a/src/lib/auth/cronPath.d.ts
+++ b/src/lib/auth/cronPath.d.ts
@@ -1,0 +1,1 @@
+export function isCronRoutePath(pathname: string): boolean

--- a/src/lib/auth/cronPath.js
+++ b/src/lib/auth/cronPath.js
@@ -1,0 +1,5 @@
+const CRON_PREFIX = "/api/cron"
+
+export function isCronRoutePath(pathname) {
+  return pathname === CRON_PREFIX || pathname.startsWith(`${CRON_PREFIX}/`)
+}

--- a/src/lib/auth/cronPath.test.mjs
+++ b/src/lib/auth/cronPath.test.mjs
@@ -1,0 +1,15 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+
+import { isCronRoutePath } from "./cronPath.js"
+
+test("isCronRoutePath matches the cron route family only", () => {
+  assert.equal(isCronRoutePath("/api/cron"), true)
+  assert.equal(isCronRoutePath("/api/cron/lock-picks"), true)
+  assert.equal(isCronRoutePath("/api/cron/sync-schedule"), true)
+
+  assert.equal(isCronRoutePath("/api/cron-status"), false)
+  assert.equal(isCronRoutePath("/api/cronjobs"), false)
+  assert.equal(isCronRoutePath("/api/cronicle"), false)
+  assert.equal(isCronRoutePath("/api/cronish/path"), false)
+})

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,6 +4,7 @@ import NextAuth from "next-auth";
 import { authConfig } from "@/auth.config";
 import type { Session } from "next-auth";
 import { isBearerAuthApiRoute } from "@/lib/auth/bearerRoute";
+import { isCronRoutePath } from "@/lib/auth/cronPath";
 
 const { auth } = NextAuth(authConfig);
 
@@ -16,9 +17,6 @@ const PUBLIC_PREFIXES = ["/races/", "/profile/"];
 
 // Prefix for all Auth.js internal API routes.
 const AUTH_PREFIX = "/api/auth";
-
-// Prefix for cron endpoints — protected by secret header, not session.
-const CRON_PREFIX = "/api/cron";
 
 // Prefix for the onboarding flow — authenticated users without a username
 // must be allowed through here.
@@ -61,7 +59,7 @@ export default auth((req: NextAuthRequest) => {
   }
 
   // ── 2. Cron routes — validated by CRON_SECRET header, not session ─────
-  if (pathname.startsWith(CRON_PREFIX)) {
+  if (isCronRoutePath(pathname)) {
     const cronSecret = process.env.CRON_SECRET;
     const authHeader = req.headers.get("authorization");
     const provided = authHeader?.startsWith("Bearer ")


### PR DESCRIPTION
Closes #150

## Summary
- add a tested cron route path predicate with a segment boundary
- use the predicate in middleware so `/api/cron-status` and similar sibling routes are not treated as cron endpoints
- include the cron route boundary regression in `npm run test:auth`

## Test Plan
- [x] `node --test src/lib/auth/cronPath.test.mjs`
- [x] `npm run test:auth`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

— gib
