### PR TITLE
Expose iOS diagnostics in debug profiles

### DIFF
--- a/ios/FXRacing/Features/Profile/GuestProfileView.swift
+++ b/ios/FXRacing/Features/Profile/GuestProfileView.swift
@@ -99,6 +99,20 @@ struct GuestProfileView: View {
                 }
             }
 
+            #if DEBUG
+            Section("Developer") {
+                NavigationLink {
+                    DiagnosticsView()
+                } label: {
+                    Label {
+                        Text("Diagnostics")
+                    } icon: {
+                        Image(systemName: "stethoscope")
+                    }
+                }
+            }
+            #endif
+
             // Sign-in CTA
             Section {
                 Button {

--- a/ios/FXRacing/Features/Profile/SettingsView.swift
+++ b/ios/FXRacing/Features/Profile/SettingsView.swift
@@ -77,6 +77,20 @@ struct SettingsView: View {
                     }
                 }
 
+                #if DEBUG
+                Section("Developer") {
+                    NavigationLink {
+                        DiagnosticsView()
+                    } label: {
+                        Label {
+                            Text("Diagnostics")
+                        } icon: {
+                            Image(systemName: "stethoscope")
+                        }
+                    }
+                }
+                #endif
+
                 Section {
                     Button("Sign Out", role: .destructive) {
                         showSignOutConfirm = true

--- a/ios/diagnostics-entry.test.mjs
+++ b/ios/diagnostics-entry.test.mjs
@@ -1,0 +1,35 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const settings = await readFile(
+  new URL("./FXRacing/Features/Profile/SettingsView.swift", import.meta.url),
+  "utf8",
+)
+const guestProfile = await readFile(
+  new URL("./FXRacing/Features/Profile/GuestProfileView.swift", import.meta.url),
+  "utf8",
+)
+
+function assertDebugDiagnosticsEntry(source, surfaceName) {
+  const debugBlock = /#if DEBUG[\s\S]*NavigationLink[\s\S]*DiagnosticsView\(\)[\s\S]*Text\("Diagnostics"\)[\s\S]*#endif/
+
+  assert.match(
+    source,
+    debugBlock,
+    `${surfaceName} should expose DiagnosticsView behind a DEBUG-only NavigationLink`,
+  )
+  assert.doesNotMatch(
+    source.replace(/#if DEBUG[\s\S]*?#endif/g, ""),
+    /DiagnosticsView\(\)|Text\("Diagnostics"\)/,
+    `${surfaceName} should not reference diagnostics outside DEBUG blocks`,
+  )
+}
+
+test("SettingsView exposes DiagnosticsView only in DEBUG builds", () => {
+  assertDebugDiagnosticsEntry(settings, "SettingsView")
+})
+
+test("GuestProfileView exposes DiagnosticsView only in DEBUG builds", () => {
+  assertDebugDiagnosticsEntry(guestProfile, "GuestProfileView")
+})

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:auth": "node --test src/lib/auth/session-cutoff.test.mjs src/lib/auth/cronPath.test.mjs",
     "test:db": "node --test src/lib/db/token-field-transform.test.mjs",
     "test:components": "node --test src/components/ui/segmented-control.test.mjs 'src/app/(main)/profile/profile-async-guards.test.mjs' src/components/picks/PickHero.test.mjs",
-    "test:ios": "node --test ios/project-signing.test.mjs ios/signin-view-model.test.mjs",
+    "test:ios": "node --test ios/project-signing.test.mjs ios/signin-view-model.test.mjs ios/diagnostics-entry.test.mjs",
     "test:ios-config": "node --test ios/project-signing.test.mjs",
     "test:pages": "node --test 'src/app/(main)/races/race-detail-page.test.mjs' 'src/app/(auth)/onboarding/username/page.test.mjs' 'src/app/(main)/leaderboard/search-params.test.mjs'",
     "test:scoring": "node --test src/lib/scoring/formula.test.mjs",


### PR DESCRIPTION
Closes #152

## Summary
- add DEBUG-only Diagnostics navigation rows to authenticated settings and guest profile
- keep all DiagnosticsView references inside `#if DEBUG` so release builds do not expose the developer surface
- add an iOS source regression check for both profile surfaces

## Test Plan
- [x] `npm run test:ios`
- [x] `cd ios && xcodebuild -project FXRacing.xcodeproj -scheme FXRacing -destination 'generic/platform=iOS Simulator' build`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

— gib
