### PR TITLE
Encode profile user API keys

### DIFF
--- a/src/app/(main)/profile/[userId]/page.tsx
+++ b/src/app/(main)/profile/[userId]/page.tsx
@@ -287,7 +287,7 @@ function Section({
 export default function FriendProfilePage() {
   const { userId } = useParams<{ userId: string }>()
   const { data, isLoading, error } = useSWR<ProfileData>(
-    userId ? `/api/users/${userId}` : null,
+    userId ? `/api/users/${encodeURIComponent(userId)}` : null,
     fetcher,
   )
   const [selectedDetail, setSelectedDetail] = React.useState<DetailState>(null)

--- a/src/app/(main)/profile/profile-async-guards.test.mjs
+++ b/src/app/(main)/profile/profile-async-guards.test.mjs
@@ -22,3 +22,10 @@ test("team picker ignores stale async save responses", async () => {
   assert.match(text, /saveRequestRef\.current !== requestId/)
   assert.doesNotMatch(text, /setSelected\(selected\) \/\/ revert/)
 })
+
+test("friend profile API key encodes dynamic user ids", async () => {
+  const text = await source("./[userId]/page.tsx")
+
+  assert.match(text, /`\/api\/users\/\$\{encodeURIComponent\(userId\)\}`/)
+  assert.doesNotMatch(text, /`\/api\/users\/\$\{userId\}`/)
+})


### PR DESCRIPTION
Closes #153

## Summary
- encode the dynamic profile `userId` before building the `/api/users/...` SWR key
- add a regression check that rejects direct userId interpolation in the profile API key

## Test Plan
- [x] `npm run test:components`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

— gib
