### PR TITLE
Use standard leaderboard ranks

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:pages": "node --test 'src/app/(main)/races/race-detail-page.test.mjs' 'src/app/(auth)/onboarding/username/page.test.mjs' 'src/app/(main)/leaderboard/search-params.test.mjs'",
     "test:scoring": "node --test src/lib/scoring/formula.test.mjs",
     "test:scripts": "node --test scripts/find-cheated-picks.test.mjs",
-    "test:services": "node --test src/lib/services/race.service.test.mjs",
+    "test:services": "node --test src/lib/services/race.service.test.mjs src/lib/services/leaderboard-rank.test.mjs",
     "lint": "next lint",
     "db:push": "prisma db push",
     "db:studio": "prisma studio",

--- a/src/lib/services/leaderboard-rank.d.ts
+++ b/src/lib/services/leaderboard-rank.d.ts
@@ -1,0 +1,3 @@
+import type { LeaderboardRow } from '@/types/domain'
+
+export function rankRows(rows: Array<Omit<LeaderboardRow, 'rank'>>): LeaderboardRow[]

--- a/src/lib/services/leaderboard-rank.js
+++ b/src/lib/services/leaderboard-rank.js
@@ -1,0 +1,34 @@
+function compareLeaderboardRows(a, b) {
+  if (b.totalScore !== a.totalScore) return b.totalScore - a.totalScore
+  if (b.exactTenthHits !== a.exactTenthHits) return b.exactTenthHits - a.exactTenthHits
+  if (b.winnerHits !== a.winnerHits) return b.winnerHits - a.winnerHits
+  if (b.dnfHits !== a.dnfHits) return b.dnfHits - a.dnfHits
+  return a.userId.localeCompare(b.userId)
+}
+
+function hasSameRankScore(a, b) {
+  return (
+    a.totalScore === b.totalScore &&
+    a.exactTenthHits === b.exactTenthHits &&
+    a.winnerHits === b.winnerHits &&
+    a.dnfHits === b.dnfHits
+  )
+}
+
+export function rankRows(rows) {
+  const sorted = [...rows].sort(compareLeaderboardRows)
+  let previous = null
+  let rank = 0
+
+  return sorted.map((row, index) => {
+    if (!previous || !hasSameRankScore(row, previous)) {
+      rank = index + 1
+    }
+    previous = row
+
+    return {
+      rank,
+      ...row,
+    }
+  })
+}

--- a/src/lib/services/leaderboard-rank.test.mjs
+++ b/src/lib/services/leaderboard-rank.test.mjs
@@ -1,0 +1,55 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+
+import { rankRows } from "./leaderboard-rank.js"
+
+function row(userId, overrides = {}) {
+  return {
+    userId,
+    publicUsername: userId,
+    avatarUrl: null,
+    teamLogoUrl: null,
+    teamColor: null,
+    totalScore: 0,
+    exactTenthHits: 0,
+    winnerHits: 0,
+    dnfHits: 0,
+    ...overrides,
+  }
+}
+
+test("rankRows assigns standard competition ranks to scoring ties", () => {
+  const ranked = rankRows([
+    row("charlie", { totalScore: 10 }),
+    row("bravo", { totalScore: 20, exactTenthHits: 1 }),
+    row("alpha", { totalScore: 20, exactTenthHits: 1 }),
+    row("delta", { totalScore: 5 }),
+  ])
+
+  assert.deepEqual(
+    ranked.map(({ userId, rank }) => ({ userId, rank })),
+    [
+      { userId: "alpha", rank: 1 },
+      { userId: "bravo", rank: 1 },
+      { userId: "charlie", rank: 3 },
+      { userId: "delta", rank: 4 },
+    ],
+  )
+})
+
+test("rankRows uses scoring tiebreakers before shared-rank comparison", () => {
+  const ranked = rankRows([
+    row("alpha", { totalScore: 20, exactTenthHits: 1 }),
+    row("bravo", { totalScore: 20, exactTenthHits: 2 }),
+    row("charlie", { totalScore: 20, exactTenthHits: 1 }),
+  ])
+
+  assert.deepEqual(
+    ranked.map(({ userId, rank }) => ({ userId, rank })),
+    [
+      { userId: "bravo", rank: 1 },
+      { userId: "alpha", rank: 2 },
+      { userId: "charlie", rank: 2 },
+    ],
+  )
+})

--- a/src/lib/services/leaderboard.service.ts
+++ b/src/lib/services/leaderboard.service.ts
@@ -10,10 +10,11 @@
  */
 
 import { db } from '@/lib/db/client'
-import type { LeaderboardRow } from '@/types/domain'
 import { getScoringCaps } from '@/lib/scoring/formula'
 import { TEAMS } from '@/lib/f1/teams'
 import type { TeamSlug } from '@/lib/f1/teams'
+import type { LeaderboardRow } from '@/types/domain'
+import { rankRows } from './leaderboard-rank'
 
 // ─────────────────────────────────────────────
 // Internal types
@@ -158,26 +159,6 @@ async function buildZeroedRows(userIds: string[]): Promise<AggregatedRow[]> {
       dnfHits: 0,
     }
   })
-}
-
-/**
- * Sort rows by tie-break rules and assign sequential ranks.
- * Equal scores receive the same rank (dense ranking not used — standard ranking).
- */
-function rankRows(rows: AggregatedRow[]): LeaderboardRow[] {
-  const sorted = [...rows].sort((a, b) => {
-    if (b.totalScore !== a.totalScore) return b.totalScore - a.totalScore
-    if (b.exactTenthHits !== a.exactTenthHits) return b.exactTenthHits - a.exactTenthHits
-    if (b.winnerHits !== a.winnerHits) return b.winnerHits - a.winnerHits
-    if (b.dnfHits !== a.dnfHits) return b.dnfHits - a.dnfHits
-    // Stable alphabetical fallback
-    return a.userId.localeCompare(b.userId)
-  })
-
-  return sorted.map((row, index) => ({
-    rank: index + 1,
-    ...row,
-  }))
 }
 
 // ─────────────────────────────────────────────


### PR DESCRIPTION
Closes #154

## Summary
- move leaderboard rank assignment into a tested pure helper
- assign standard competition ranks when rows tie on all scoring fields
- keep `userId` as a stable sort fallback without making tied scores receive different ranks

## Test Plan
- [x] `npm run test:services`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

— gib
