### PR TITLE
Guard legal modal dialog accessibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test:routes": "node --test src/app/api/account/delete-handler.test.mjs src/app/api/users/username/post-handler.test.mjs src/app/api/picks/post-handler.test.mjs src/app/api/leaderboard/get-handler.test.mjs src/app/api/friends/patch-handler.test.mjs src/app/api/cron/sync-schedule/driver-fetch.test.mjs src/app/api/cron/lock-picks/route.test.mjs src/app/api/cron/sync-entries/route.test.mjs src/app/api/diag/health/get-handler.test.mjs src/app/api/diag/race/route.test.mjs",
     "test:auth": "node --test src/lib/auth/session-cutoff.test.mjs src/lib/auth/cronPath.test.mjs",
     "test:db": "node --test src/lib/db/token-field-transform.test.mjs",
-    "test:components": "node --test src/components/ui/segmented-control.test.mjs 'src/app/(main)/profile/profile-async-guards.test.mjs' src/components/picks/PickHero.test.mjs",
+    "test:components": "node --test src/components/ui/segmented-control.test.mjs 'src/app/(main)/profile/profile-async-guards.test.mjs' src/components/picks/PickHero.test.mjs src/components/legal/LegalModal.test.mjs",
     "test:ios": "node --test ios/project-signing.test.mjs ios/signin-view-model.test.mjs ios/diagnostics-entry.test.mjs",
     "test:ios-config": "node --test ios/project-signing.test.mjs",
     "test:pages": "node --test 'src/app/(main)/races/race-detail-page.test.mjs' 'src/app/(auth)/onboarding/username/page.test.mjs' 'src/app/(main)/leaderboard/search-params.test.mjs'",

--- a/src/components/legal/LegalModal.test.mjs
+++ b/src/components/legal/LegalModal.test.mjs
@@ -1,0 +1,19 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const source = await readFile(new URL("./LegalModal.tsx", import.meta.url), "utf8")
+
+test("LegalModal uses Radix Dialog primitives for modal accessibility", () => {
+  assert.match(source, /import \* as Dialog from '@radix-ui\/react-dialog'/)
+  assert.match(source, /<Dialog\.Root\b/)
+  assert.match(source, /<Dialog\.Trigger\b/)
+  assert.match(source, /<Dialog\.Portal\b/)
+  assert.match(source, /<Dialog\.Overlay\b/)
+  assert.match(source, /<Dialog\.Content\b/)
+  assert.match(source, /<Dialog\.Title\b[\s\S]*Legal &amp; Support[\s\S]*<\/Dialog\.Title>/)
+  assert.match(source, /<Dialog\.Description\b/)
+  assert.match(source, /<Dialog\.Close\b/)
+  assert.doesNotMatch(source, /window\.addEventListener\('keydown'/)
+  assert.doesNotMatch(source, /onClick=\{handleBackdrop\}/)
+})

--- a/src/components/legal/LegalModal.tsx
+++ b/src/components/legal/LegalModal.tsx
@@ -151,6 +151,9 @@ export function LegalModal() {
               <Dialog.Title className="text-sm font-bold text-text-primary">
                 Legal &amp; Support
               </Dialog.Title>
+              <Dialog.Description className="sr-only">
+                Privacy, terms, intellectual property, cookies, and support information for FX Racing.
+              </Dialog.Description>
               <Dialog.Close
                 className="flex h-8 w-8 items-center justify-center rounded-full bg-surface-elevated hover:bg-surface-elevated/80 transition-colors"
                 aria-label="Close"


### PR DESCRIPTION
Closes #155

## Summary
- add a hidden Radix `Dialog.Description` so LegalModal has both title and description metadata
- add a regression check that LegalModal uses Radix Dialog primitives instead of manual backdrop/Escape handling
- include the legal modal check in `npm run test:components`

## Test Plan
- [x] `npm run test:components`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

— gib
