### PR TITLE
Cover users me route handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "prisma generate && next build",
     "start": "next start",
-    "test:routes": "node --test src/app/api/account/delete-handler.test.mjs src/app/api/users/username/post-handler.test.mjs src/app/api/picks/post-handler.test.mjs src/app/api/leaderboard/get-handler.test.mjs src/app/api/friends/patch-handler.test.mjs src/app/api/cron/sync-schedule/driver-fetch.test.mjs src/app/api/cron/lock-picks/route.test.mjs src/app/api/cron/sync-entries/route.test.mjs src/app/api/diag/health/get-handler.test.mjs src/app/api/diag/race/route.test.mjs",
+    "test:routes": "node --test src/app/api/account/delete-handler.test.mjs src/app/api/users/username/post-handler.test.mjs src/app/api/users/me/get-handler.test.mjs src/app/api/picks/post-handler.test.mjs src/app/api/leaderboard/get-handler.test.mjs src/app/api/friends/patch-handler.test.mjs src/app/api/cron/sync-schedule/driver-fetch.test.mjs src/app/api/cron/lock-picks/route.test.mjs src/app/api/cron/sync-entries/route.test.mjs src/app/api/diag/health/get-handler.test.mjs src/app/api/diag/race/route.test.mjs",
     "test:auth": "node --test src/lib/auth/session-cutoff.test.mjs src/lib/auth/cronPath.test.mjs",
     "test:db": "node --test src/lib/db/token-field-transform.test.mjs",
     "test:components": "node --test src/components/ui/segmented-control.test.mjs 'src/app/(main)/profile/profile-async-guards.test.mjs' src/components/picks/PickHero.test.mjs src/components/legal/LegalModal.test.mjs",

--- a/src/app/api/users/me/get-handler.js
+++ b/src/app/api/users/me/get-handler.js
@@ -1,0 +1,46 @@
+export async function handleUsersMeGet(
+  req,
+  {
+    auth,
+    mobileAuth,
+    db,
+  },
+) {
+  const session = (await auth()) ?? (await mobileAuth(req))
+  if (!session?.user?.id) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const user = await db.user.findUnique({
+    where: { id: session.user.id },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      image: true,
+      publicUsername: true,
+      usernameSet: true,
+      usernameChangeUsed: true,
+      favoriteTeamSlug: true,
+      tutorialDismissedAt: true,
+      createdAt: true,
+    },
+  })
+
+  if (!user) {
+    return Response.json({ error: "User not found" }, { status: 404 })
+  }
+
+  return Response.json({
+    id: user.id,
+    name: user.name,
+    email: user.email,
+    avatarUrl: user.image,
+    publicUsername: user.publicUsername,
+    usernameSet: user.usernameSet,
+    usernameChangeUsed: user.usernameChangeUsed,
+    favoriteTeamSlug: user.favoriteTeamSlug,
+    tutorialDismissedAt: user.tutorialDismissedAt?.toISOString() ?? null,
+    createdAt: user.createdAt.toISOString(),
+  })
+}

--- a/src/app/api/users/me/get-handler.test.mjs
+++ b/src/app/api/users/me/get-handler.test.mjs
@@ -1,0 +1,130 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+
+import { handleUsersMeGet } from "./get-handler.js"
+
+function request() {
+  return new Request("http://localhost/api/users/me")
+}
+
+function dependencies(overrides = {}) {
+  return {
+    auth: async () => null,
+    mobileAuth: async () => null,
+    db: {
+      user: {
+        findUnique: async () => null,
+      },
+    },
+    ...overrides,
+  }
+}
+
+function user(overrides = {}) {
+  return {
+    id: "user-1",
+    name: "Test User",
+    email: "test@example.com",
+    image: "https://example.com/avatar.png",
+    publicUsername: "testuser",
+    usernameSet: true,
+    usernameChangeUsed: false,
+    favoriteTeamSlug: "ferrari",
+    tutorialDismissedAt: null,
+    createdAt: new Date("2026-06-01T12:00:00.000Z"),
+    ...overrides,
+  }
+}
+
+test("GET /api/users/me returns 401 without cookie or bearer auth", async () => {
+  const calls = []
+  const response = await handleUsersMeGet(
+    request(),
+    dependencies({
+      db: {
+        user: {
+          findUnique: async () => {
+            calls.push("findUnique")
+            return null
+          },
+        },
+      },
+    }),
+  )
+
+  assert.equal(response.status, 401)
+  assert.deepEqual(await response.json(), { error: "Unauthorized" })
+  assert.deepEqual(calls, [])
+})
+
+test("GET /api/users/me falls back to bearer auth and returns 404 for a missing user", async () => {
+  const findCalls = []
+  const response = await handleUsersMeGet(
+    request(),
+    dependencies({
+      mobileAuth: async () => ({ user: { id: "mobile-user" } }),
+      db: {
+        user: {
+          findUnique: async (query) => {
+            findCalls.push(query)
+            return null
+          },
+        },
+      },
+    }),
+  )
+
+  assert.equal(response.status, 404)
+  assert.equal(findCalls[0].where.id, "mobile-user")
+  assert.deepEqual(await response.json(), { error: "User not found" })
+})
+
+test("GET /api/users/me serializes nullable and populated profile dates", async () => {
+  const responseWithNullTutorial = await handleUsersMeGet(
+    request(),
+    dependencies({
+      auth: async () => ({ user: { id: "user-1" } }),
+      mobileAuth: async () => {
+        throw new Error("mobileAuth should not run when cookie auth succeeds")
+      },
+      db: {
+        user: {
+          findUnique: async () => user(),
+        },
+      },
+    }),
+  )
+
+  assert.equal(responseWithNullTutorial.status, 200)
+  assert.deepEqual(await responseWithNullTutorial.json(), {
+    id: "user-1",
+    name: "Test User",
+    email: "test@example.com",
+    avatarUrl: "https://example.com/avatar.png",
+    publicUsername: "testuser",
+    usernameSet: true,
+    usernameChangeUsed: false,
+    favoriteTeamSlug: "ferrari",
+    tutorialDismissedAt: null,
+    createdAt: "2026-06-01T12:00:00.000Z",
+  })
+
+  const responseWithTutorial = await handleUsersMeGet(
+    request(),
+    dependencies({
+      auth: async () => ({ user: { id: "user-1" } }),
+      db: {
+        user: {
+          findUnique: async () =>
+            user({ tutorialDismissedAt: new Date("2026-06-02T09:30:00.000Z") }),
+        },
+      },
+    }),
+  )
+
+  assert.equal(responseWithTutorial.status, 200)
+  assert.equal(
+    (await responseWithTutorial.json()).tutorialDismissedAt,
+    "2026-06-02T09:30:00.000Z",
+  )
+})

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -7,47 +7,15 @@
  * Supports both cookie-based sessions (web) and Bearer tokens (iOS native).
  */
 
-import { NextResponse } from 'next/server'
 import { auth } from '@/auth'
 import { mobileAuth } from '@/lib/auth/mobileAuth'
 import { db } from '@/lib/db/client'
+import { handleUsersMeGet } from './get-handler'
 
 export async function GET(req: Request) {
-  const session = (await auth()) ?? (await mobileAuth(req))
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
-
-  const user = await db.user.findUnique({
-    where: { id: session.user.id },
-    select: {
-      id: true,
-      name: true,
-      email: true,
-      image: true,
-      publicUsername: true,
-      usernameSet: true,
-      usernameChangeUsed: true,
-      favoriteTeamSlug: true,
-      tutorialDismissedAt: true,
-      createdAt: true,
-    },
-  })
-
-  if (!user) {
-    return NextResponse.json({ error: 'User not found' }, { status: 404 })
-  }
-
-  return NextResponse.json({
-    id: user.id,
-    name: user.name,
-    email: user.email,
-    avatarUrl: user.image,
-    publicUsername: user.publicUsername,
-    usernameSet: user.usernameSet,
-    usernameChangeUsed: user.usernameChangeUsed,
-    favoriteTeamSlug: user.favoriteTeamSlug,
-    tutorialDismissedAt: user.tutorialDismissedAt?.toISOString() ?? null,
-    createdAt: user.createdAt.toISOString(),
+  return handleUsersMeGet(req, {
+    auth,
+    mobileAuth,
+    db,
   })
 }


### PR DESCRIPTION
Closes #157

## Summary
- extract `/api/users/me` behavior into a dependency-injected GET handler
- add route-handler coverage for unauthenticated requests, Bearer auth fallback, missing users, and profile date serialization
- include the users/me handler test in `npm run test:routes`

## Test Plan
- [x] `npm run test:routes`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

— gib
