### PR TITLE
Cover authenticated session refresh guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test:routes": "node --test src/app/api/account/delete-handler.test.mjs src/app/api/users/username/post-handler.test.mjs src/app/api/users/me/get-handler.test.mjs src/app/api/picks/post-handler.test.mjs src/app/api/leaderboard/get-handler.test.mjs src/app/api/friends/patch-handler.test.mjs src/app/api/cron/sync-schedule/driver-fetch.test.mjs src/app/api/cron/lock-picks/route.test.mjs src/app/api/cron/sync-entries/route.test.mjs src/app/api/diag/health/get-handler.test.mjs src/app/api/diag/race/route.test.mjs",
     "test:auth": "node --test src/lib/auth/session-cutoff.test.mjs src/lib/auth/cronPath.test.mjs",
     "test:db": "node --test src/lib/db/token-field-transform.test.mjs",
-    "test:components": "node --test src/components/ui/segmented-control.test.mjs 'src/app/(main)/profile/profile-async-guards.test.mjs' src/components/picks/PickHero.test.mjs src/components/legal/LegalModal.test.mjs",
+    "test:components": "node --test src/components/ui/segmented-control.test.mjs 'src/app/(main)/profile/profile-async-guards.test.mjs' src/components/picks/PickHero.test.mjs src/components/legal/LegalModal.test.mjs src/components/session-sync.test.mjs",
     "test:ios": "node --test ios/project-signing.test.mjs ios/signin-view-model.test.mjs ios/diagnostics-entry.test.mjs",
     "test:ios-config": "node --test ios/project-signing.test.mjs",
     "test:pages": "node --test 'src/app/(main)/races/race-detail-page.test.mjs' 'src/app/(auth)/onboarding/username/page.test.mjs' 'src/app/(main)/leaderboard/search-params.test.mjs'",

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -3,6 +3,7 @@
 import { SessionProvider, useSession } from "next-auth/react"
 import { useRouter } from "next/navigation"
 import { useEffect, useRef } from "react"
+import { shouldRefreshForSessionStatus } from "./session-sync"
 
 /**
  * Calls router.refresh() whenever the session transitions to authenticated.
@@ -16,7 +17,7 @@ function SessionSync() {
   const prevStatus = useRef(status)
 
   useEffect(() => {
-    if (prevStatus.current !== "authenticated" && status === "authenticated") {
+    if (shouldRefreshForSessionStatus(prevStatus.current, status)) {
       router.refresh()
     }
     prevStatus.current = status

--- a/src/components/session-sync.d.ts
+++ b/src/components/session-sync.d.ts
@@ -1,0 +1,1 @@
+export function shouldRefreshForSessionStatus(previousStatus: string, status: string): boolean

--- a/src/components/session-sync.js
+++ b/src/components/session-sync.js
@@ -1,0 +1,3 @@
+export function shouldRefreshForSessionStatus(previousStatus, status) {
+  return previousStatus !== "authenticated" && status === "authenticated"
+}

--- a/src/components/session-sync.test.mjs
+++ b/src/components/session-sync.test.mjs
@@ -1,0 +1,32 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+
+import { shouldRefreshForSessionStatus } from "./session-sync.js"
+
+test("shouldRefreshForSessionStatus only refreshes when entering authenticated", () => {
+  const sequence = [
+    "loading",
+    "unauthenticated",
+    "authenticated",
+    "authenticated",
+    "unauthenticated",
+    "authenticated",
+  ]
+  const refreshes = []
+  let previous = sequence[0]
+
+  for (const status of sequence.slice(1)) {
+    if (shouldRefreshForSessionStatus(previous, status)) {
+      refreshes.push({ previous, status })
+    }
+    previous = status
+  }
+
+  assert.deepEqual(refreshes, [
+    { previous: "unauthenticated", status: "authenticated" },
+    { previous: "unauthenticated", status: "authenticated" },
+  ])
+  assert.equal(shouldRefreshForSessionStatus("loading", "authenticated"), true)
+  assert.equal(shouldRefreshForSessionStatus("authenticated", "authenticated"), false)
+  assert.equal(shouldRefreshForSessionStatus("authenticated", "unauthenticated"), false)
+})


### PR DESCRIPTION
Closes #158

## Summary
- extract the authenticated-session transition guard into a tested helper
- keep `Providers` calling `router.refresh()` only when entering authenticated status
- include the session refresh guard regression in `npm run test:components`

## Test Plan
- [x] `npm run test:components`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

— gib
