### PR TITLE
Cover lock countdown transition behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test:routes": "node --test src/app/api/account/delete-handler.test.mjs src/app/api/users/username/post-handler.test.mjs src/app/api/users/me/get-handler.test.mjs src/app/api/picks/post-handler.test.mjs src/app/api/leaderboard/get-handler.test.mjs src/app/api/friends/patch-handler.test.mjs src/app/api/cron/sync-schedule/driver-fetch.test.mjs src/app/api/cron/lock-picks/route.test.mjs src/app/api/cron/sync-entries/route.test.mjs src/app/api/diag/health/get-handler.test.mjs src/app/api/diag/race/route.test.mjs",
     "test:auth": "node --test src/lib/auth/session-cutoff.test.mjs src/lib/auth/cronPath.test.mjs",
     "test:db": "node --test src/lib/db/token-field-transform.test.mjs",
-    "test:components": "node --test src/components/ui/segmented-control.test.mjs 'src/app/(main)/profile/profile-async-guards.test.mjs' src/components/picks/PickHero.test.mjs src/components/legal/LegalModal.test.mjs src/components/session-sync.test.mjs",
+    "test:components": "node --test src/components/ui/segmented-control.test.mjs 'src/app/(main)/profile/profile-async-guards.test.mjs' src/components/picks/PickHero.test.mjs src/components/legal/LegalModal.test.mjs src/components/session-sync.test.mjs src/components/race/lock-countdown-timer.test.mjs",
     "test:ios": "node --test ios/project-signing.test.mjs ios/signin-view-model.test.mjs ios/diagnostics-entry.test.mjs",
     "test:ios-config": "node --test ios/project-signing.test.mjs",
     "test:pages": "node --test 'src/app/(main)/races/race-detail-page.test.mjs' 'src/app/(auth)/onboarding/username/page.test.mjs' 'src/app/(main)/leaderboard/search-params.test.mjs'",

--- a/src/components/race/LockCountdown.tsx
+++ b/src/components/race/LockCountdown.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { Lock } from 'lucide-react'
 
 import { cn, msToCountdown } from '@/lib/utils'
+import { createLockCountdownTimer } from './lock-countdown-timer'
 
 export interface LockCountdownProps {
   /** ISO 8601 timestamp string — must be parseable by `new Date()` */
@@ -27,20 +28,11 @@ export function LockCountdown({
   onLockedRef.current = onLocked
 
   React.useEffect(() => {
-    const tick = () => {
-      const remaining = cutoff - Date.now()
-      setMsLeft(remaining)
-
-      // Fire callback once when we cross the threshold
-      if (remaining <= 0) {
-        clearInterval(id)
-        onLockedRef.current?.()
-      }
-    }
-
-    const id = setInterval(tick, 1_000)
-    tick() // run immediately to avoid 1-second blank
-    return () => clearInterval(id)
+    return createLockCountdownTimer({
+      cutoff,
+      onTick: setMsLeft,
+      onLocked: () => onLockedRef.current?.(),
+    })
   }, [cutoff])
 
   // Locked state

--- a/src/components/race/lock-countdown-timer.d.ts
+++ b/src/components/race/lock-countdown-timer.d.ts
@@ -1,0 +1,14 @@
+type LockCountdownTimerId = ReturnType<typeof setInterval>
+
+type LockCountdownTimerOptions = {
+  cutoff: number
+  now?: () => number
+  setIntervalFn?: (callback: () => void, delay: number) => LockCountdownTimerId
+  clearIntervalFn?: (id: LockCountdownTimerId) => void
+  onTick: (remainingMs: number) => void
+  onLocked?: () => void
+}
+
+export function createLockCountdownTimer(
+  options: LockCountdownTimerOptions,
+): () => void

--- a/src/components/race/lock-countdown-timer.js
+++ b/src/components/race/lock-countdown-timer.js
@@ -1,0 +1,33 @@
+export function createLockCountdownTimer({
+  cutoff,
+  now = () => Date.now(),
+  setIntervalFn = setInterval,
+  clearIntervalFn = clearInterval,
+  onTick,
+  onLocked,
+}) {
+  let intervalId
+  let locked = false
+
+  const tick = () => {
+    const remaining = cutoff - now()
+    onTick(remaining)
+
+    if (remaining <= 0 && !locked) {
+      locked = true
+      if (intervalId !== undefined) {
+        clearIntervalFn(intervalId)
+      }
+      onLocked?.()
+    }
+  }
+
+  intervalId = setIntervalFn(tick, 1_000)
+  tick()
+
+  return () => {
+    if (intervalId !== undefined) {
+      clearIntervalFn(intervalId)
+    }
+  }
+}

--- a/src/components/race/lock-countdown-timer.test.mjs
+++ b/src/components/race/lock-countdown-timer.test.mjs
@@ -1,0 +1,113 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+
+import { createLockCountdownTimer } from "./lock-countdown-timer.js"
+
+function fakeTimers(nowRef) {
+  let nextId = 1
+  const callbacks = new Map()
+  const cleared = []
+
+  return {
+    callbacks,
+    cleared,
+    setIntervalFn(callback, delay) {
+      const id = nextId++
+      callbacks.set(id, { callback, delay })
+      return id
+    },
+    clearIntervalFn(id) {
+      cleared.push(id)
+      callbacks.delete(id)
+    },
+    fire(id) {
+      callbacks.get(id)?.callback()
+    },
+    now() {
+      return nowRef.value
+    },
+  }
+}
+
+test("createLockCountdownTimer ticks until cutoff and locks once", () => {
+  const nowRef = { value: 0 }
+  const timers = fakeTimers(nowRef)
+  const ticks = []
+  let lockedCalls = 0
+
+  const cleanup = createLockCountdownTimer({
+    cutoff: 2_500,
+    now: timers.now,
+    setIntervalFn: timers.setIntervalFn.bind(timers),
+    clearIntervalFn: timers.clearIntervalFn.bind(timers),
+    onTick: (remaining) => ticks.push(remaining),
+    onLocked: () => {
+      lockedCalls += 1
+    },
+  })
+
+  assert.deepEqual(ticks, [2_500])
+  const [intervalId] = timers.callbacks.keys()
+  assert.equal(timers.callbacks.get(intervalId).delay, 1_000)
+
+  nowRef.value = 1_000
+  timers.fire(intervalId)
+  assert.deepEqual(ticks, [2_500, 1_500])
+  assert.equal(lockedCalls, 0)
+
+  nowRef.value = 3_000
+  timers.fire(intervalId)
+  assert.deepEqual(ticks, [2_500, 1_500, -500])
+  assert.equal(lockedCalls, 1)
+  assert.deepEqual(timers.cleared, [intervalId])
+
+  cleanup()
+  assert.equal(lockedCalls, 1)
+})
+
+test("createLockCountdownTimer locks immediately when cutoff already passed", () => {
+  const nowRef = { value: 10_000 }
+  const timers = fakeTimers(nowRef)
+  const ticks = []
+  let lockedCalls = 0
+
+  createLockCountdownTimer({
+    cutoff: 9_000,
+    now: timers.now,
+    setIntervalFn: timers.setIntervalFn.bind(timers),
+    clearIntervalFn: timers.clearIntervalFn.bind(timers),
+    onTick: (remaining) => ticks.push(remaining),
+    onLocked: () => {
+      lockedCalls += 1
+    },
+  })
+
+  assert.deepEqual(ticks, [-1_000])
+  assert.equal(lockedCalls, 1)
+  assert.deepEqual([...timers.callbacks.keys()], [])
+})
+
+test("createLockCountdownTimer cleanup stops future ticks before cutoff", () => {
+  const nowRef = { value: 0 }
+  const timers = fakeTimers(nowRef)
+  let lockedCalls = 0
+
+  const cleanup = createLockCountdownTimer({
+    cutoff: 10_000,
+    now: timers.now,
+    setIntervalFn: timers.setIntervalFn.bind(timers),
+    clearIntervalFn: timers.clearIntervalFn.bind(timers),
+    onTick: () => {},
+    onLocked: () => {
+      lockedCalls += 1
+    },
+  })
+  const [intervalId] = timers.callbacks.keys()
+
+  cleanup()
+  nowRef.value = 20_000
+  timers.fire(intervalId)
+
+  assert.equal(lockedCalls, 0)
+  assert.deepEqual(timers.cleared, [intervalId])
+})


### PR DESCRIPTION
Closes #160

## Summary
- extract LockCountdown interval behavior into an injected timer helper
- add regression coverage for countdown ticks, lock transition, exactly-once onLocked, and cleanup
- include the lock countdown timer test in `npm run test:components`

## Test Plan
- [x] `npm run test:components`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

— gib
