### PR TITLE
Refresh own profile after settings changes

### DIFF
--- a/ios/FXRacing/Features/Profile/ProfileView.swift
+++ b/ios/FXRacing/Features/Profile/ProfileView.swift
@@ -5,6 +5,10 @@ struct ProfileView: View {
     @State private var vm: FriendProfileViewModel? = nil
     @State private var showSettings = false
 
+    private var profileRefreshKey: ProfileRefreshKey {
+        ProfileRefreshKey(user: authManager.authenticatedUser)
+    }
+
     var body: some View {
         Group {
             if authManager.isAuthenticated {
@@ -53,7 +57,7 @@ struct ProfileView: View {
                 ownProfileList(profile, vm: profileVm)
             }
         }
-        .task { await profileVm.load(token: authManager.accessToken) }
+        .task(id: profileRefreshKey) { await profileVm.load(token: authManager.accessToken) }
         .refreshable { await profileVm.load(token: authManager.accessToken) }
     }
 
@@ -173,5 +177,17 @@ struct ProfileView: View {
         Circle()
             .fill(color)
             .frame(width: 6, height: 6)
+    }
+}
+
+private struct ProfileRefreshKey: Equatable {
+    let userId: String?
+    let publicUsername: String?
+    let favoriteTeamSlug: String?
+
+    init(user: User?) {
+        userId = user?.id
+        publicUsername = user?.publicUsername
+        favoriteTeamSlug = user?.favoriteTeamSlug
     }
 }

--- a/ios/profile-refresh-key.test.mjs
+++ b/ios/profile-refresh-key.test.mjs
@@ -1,0 +1,26 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const source = await readFile(
+  new URL("./FXRacing/Features/Profile/ProfileView.swift", import.meta.url),
+  "utf8",
+)
+
+test("ProfileView reloads own profile when display-affecting auth fields change", () => {
+  assert.match(
+    source,
+    /\.task\(id:\s*profileRefreshKey\)\s*\{\s*await profileVm\.load\(token:\s*authManager\.accessToken\)\s*\}/,
+    "profile loading should be keyed so auth field updates refresh the current profile",
+  )
+  assert.match(
+    source,
+    /private var profileRefreshKey:\s*ProfileRefreshKey\s*\{\s*ProfileRefreshKey\(user:\s*authManager\.authenticatedUser\)\s*\}/,
+    "ProfileView should derive the task id from the current authenticated user",
+  )
+  assert.match(
+    source,
+    /private struct ProfileRefreshKey:\s*Equatable\s*\{[\s\S]*let userId:\s*String\?[\s\S]*let publicUsername:\s*String\?[\s\S]*let favoriteTeamSlug:\s*String\?/,
+    "profile refresh key should include the fields rendered by the profile header",
+  )
+})

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:auth": "node --test src/lib/auth/session-cutoff.test.mjs src/lib/auth/cronPath.test.mjs",
     "test:db": "node --test src/lib/db/token-field-transform.test.mjs",
     "test:components": "node --test src/components/ui/segmented-control.test.mjs 'src/app/(main)/profile/profile-async-guards.test.mjs' src/components/picks/PickHero.test.mjs src/components/legal/LegalModal.test.mjs src/components/session-sync.test.mjs src/components/race/lock-countdown-timer.test.mjs",
-    "test:ios": "node --test ios/project-signing.test.mjs ios/signin-view-model.test.mjs ios/diagnostics-entry.test.mjs",
+    "test:ios": "node --test ios/project-signing.test.mjs ios/signin-view-model.test.mjs ios/diagnostics-entry.test.mjs ios/profile-refresh-key.test.mjs",
     "test:ios-config": "node --test ios/project-signing.test.mjs",
     "test:pages": "node --test 'src/app/(main)/races/race-detail-page.test.mjs' 'src/app/(auth)/onboarding/username/page.test.mjs' 'src/app/(main)/leaderboard/search-params.test.mjs'",
     "test:scoring": "node --test src/lib/scoring/formula.test.mjs",


### PR DESCRIPTION
Closes #161

## Summary
- key the own-profile load task on authenticated user fields that affect the profile header
- reload the existing profile view model when username or favorite team changes without recreating the view
- add iOS regression coverage for the keyed profile refresh wiring

## Test Plan
- [x] `npm run test:ios`
- [x] `cd ios && xcodebuild -project FXRacing.xcodeproj -scheme FXRacing -destination 'generic/platform=iOS Simulator' build`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

— gib
