### PR TITLE
Order past races by scheduled start

### DIFF
--- a/ios/FXRacing/Features/Races/RacesListViewModel.swift
+++ b/ios/FXRacing/Features/Races/RacesListViewModel.swift
@@ -16,7 +16,7 @@ final class RacesListViewModel {
     var past: [Race] {
         races
             .filter { $0.status == .completed }
-            .sorted { $0.round > $1.round }
+            .sorted { $0.scheduledStartUtc > $1.scheduledStartUtc }
     }
 
     /// True when at least one race is currently live — used by the view to

--- a/ios/races-list-ordering.test.mjs
+++ b/ios/races-list-ordering.test.mjs
@@ -1,0 +1,25 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const source = await readFile(
+  new URL("./FXRacing/Features/Races/RacesListViewModel.swift", import.meta.url),
+  "utf8",
+)
+
+test("RacesListViewModel orders completed races by scheduled start descending", () => {
+  const pastBlock = source.match(/var past:\s*\[Race\]\s*\{[\s\S]*?\n    \}/)?.[0]
+
+  assert.ok(pastBlock, "past race computed property should exist")
+  assert.match(pastBlock, /\.filter\s*\{\s*\$0\.status\s*==\s*\.completed\s*\}/)
+  assert.match(
+    pastBlock,
+    /\.sorted\s*\{\s*\$0\.scheduledStartUtc\s*>\s*\$1\.scheduledStartUtc\s*\}/,
+    "completed races should be sorted by actual start time, not just round",
+  )
+  assert.doesNotMatch(
+    pastBlock,
+    /\.sorted\s*\{\s*\$0\.round\s*>\s*\$1\.round\s*\}/,
+    "round-only sorting cannot order sprint and main races from the same weekend",
+  )
+})

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:auth": "node --test src/lib/auth/session-cutoff.test.mjs src/lib/auth/cronPath.test.mjs",
     "test:db": "node --test src/lib/db/token-field-transform.test.mjs",
     "test:components": "node --test src/components/ui/segmented-control.test.mjs 'src/app/(main)/profile/profile-async-guards.test.mjs' src/components/picks/PickHero.test.mjs src/components/legal/LegalModal.test.mjs src/components/session-sync.test.mjs src/components/race/lock-countdown-timer.test.mjs",
-    "test:ios": "node --test ios/project-signing.test.mjs ios/signin-view-model.test.mjs ios/diagnostics-entry.test.mjs ios/profile-refresh-key.test.mjs",
+    "test:ios": "node --test ios/project-signing.test.mjs ios/signin-view-model.test.mjs ios/diagnostics-entry.test.mjs ios/profile-refresh-key.test.mjs ios/races-list-ordering.test.mjs",
     "test:ios-config": "node --test ios/project-signing.test.mjs",
     "test:pages": "node --test 'src/app/(main)/races/race-detail-page.test.mjs' 'src/app/(auth)/onboarding/username/page.test.mjs' 'src/app/(main)/leaderboard/search-params.test.mjs'",
     "test:scoring": "node --test src/lib/scoring/formula.test.mjs",


### PR DESCRIPTION
Closes #162

## Summary
- sort completed iOS races by `scheduledStartUtc` descending instead of round number
- prevent same-round sprint/main weekends from rendering out of chronological order
- add iOS regression coverage for the past race ordering comparator

## Test Plan
- [x] `npm run test:ios`
- [x] `cd ios && xcodebuild -project FXRacing.xcodeproj -scheme FXRacing -destination 'generic/platform=iOS Simulator' build`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

— gib
