### PR TITLE
Include Prisma maintenance scripts in typecheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:ios-config": "node --test ios/project-signing.test.mjs",
     "test:pages": "node --test 'src/app/(main)/races/race-detail-page.test.mjs' 'src/app/(auth)/onboarding/username/page.test.mjs' 'src/app/(main)/leaderboard/search-params.test.mjs'",
     "test:scoring": "node --test src/lib/scoring/formula.test.mjs",
-    "test:scripts": "node --test scripts/find-cheated-picks.test.mjs",
+    "test:scripts": "node --test scripts/find-cheated-picks.test.mjs scripts/tsconfig-prisma-coverage.test.mjs",
     "test:services": "node --test src/lib/services/race.service.test.mjs src/lib/services/leaderboard-rank.test.mjs src/lib/services/friendship.service.test.mjs",
     "lint": "next lint",
     "db:push": "prisma db push",

--- a/prisma/fix-grid-and-results.ts
+++ b/prisma/fix-grid-and-results.ts
@@ -183,7 +183,7 @@ async function main() {
     console.log(`\n   📊 ${race.name} (session ${sessionKey})`)
 
     // Ensure race entries exist for all 22 drivers
-    for (const [code, driverId] of byCode.entries()) {
+    for (const [code, driverId] of Array.from(byCode.entries())) {
       const exists = await db.$queryRaw<Array<{id: string}>>`
         SELECT id FROM "RaceEntry" WHERE "raceId" = ${race.id} AND "driverId" = ${driverId}
       `

--- a/scripts/tsconfig-prisma-coverage.test.mjs
+++ b/scripts/tsconfig-prisma-coverage.test.mjs
@@ -1,0 +1,26 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile, readdir } from "node:fs/promises"
+
+const tsconfig = JSON.parse(
+  await readFile(new URL("../tsconfig.json", import.meta.url), "utf8"),
+)
+
+test("tsconfig includes executable Prisma TypeScript maintenance scripts", async () => {
+  const prismaFiles = await readdir(new URL("../prisma", import.meta.url))
+  const prismaTypeScriptFiles = prismaFiles.filter((file) => file.endsWith(".ts"))
+
+  assert.ok(
+    prismaTypeScriptFiles.length > 0,
+    "expected at least one Prisma TypeScript maintenance script",
+  )
+  assert.ok(
+    tsconfig.include?.some((pattern) => pattern === "**/*.ts"),
+    "the project include pattern should cover TypeScript files",
+  )
+  assert.doesNotMatch(
+    JSON.stringify(tsconfig.exclude ?? []),
+    /"prisma"/,
+    "the whole prisma directory must not be excluded from typecheck",
+  )
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules", "prisma"]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Closes #164

## Summary
- remove the broad `prisma` exclusion from `tsconfig.json`
- add a regression test that prevents excluding executable Prisma TypeScript scripts from typecheck
- fix the newly covered Prisma grid maintenance script iterator issue

## Test Plan
- [x] `npm run test:scripts`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

— gib
