### PR TITLE
Render friend profile avatar URLs

### DIFF
--- a/src/app/(main)/profile/[userId]/page.tsx
+++ b/src/app/(main)/profile/[userId]/page.tsx
@@ -331,7 +331,7 @@ export default function FriendProfilePage() {
 
         <div className="flex items-center gap-4 rounded-2xl border border-[var(--border)] bg-surface px-4 py-4">
           <Avatar
-            src={null}
+            src={user.avatarUrl}
             name={user.publicUsername ?? user.id}
             size="lg"
             teamLogoUrl={user.favoriteTeamSlug ? (TEAMS[user.favoriteTeamSlug as TeamSlug]?.logoUrl ?? null) : null}

--- a/src/app/(main)/profile/profile-async-guards.test.mjs
+++ b/src/app/(main)/profile/profile-async-guards.test.mjs
@@ -29,3 +29,13 @@ test("friend profile API key encodes dynamic user ids", async () => {
   assert.match(text, /`\/api\/users\/\$\{encodeURIComponent\(userId\)\}`/)
   assert.doesNotMatch(text, /`\/api\/users\/\$\{userId\}`/)
 })
+
+test("friend profile header passes API avatar URLs to Avatar", async () => {
+  const text = await source("./[userId]/page.tsx")
+
+  assert.match(
+    text,
+    /<Avatar[\s\S]*src=\{user\.avatarUrl\}/,
+    "profile header should render the avatar URL returned by the API",
+  )
+})


### PR DESCRIPTION
Closes #165

## Summary
- pass `user.avatarUrl` through to the friend profile header Avatar
- add a regression guard for the profile avatar data flow

## Test Plan
- [x] `npm run test:components`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

— gib
