### PR TITLE
Hide stale saved pick feedback

### DIFF
--- a/src/components/picks/PickHero.test.mjs
+++ b/src/components/picks/PickHero.test.mjs
@@ -11,3 +11,10 @@ test("PickHero preserves unauthenticated picks across sign-in", () => {
   assert.match(source, /submitPickPayload\(pendingPick\)/)
   assert.match(source, /window\.localStorage\.removeItem\(storageKey\)/)
 })
+
+test("PickHero hides saved feedback after local selections change", () => {
+  assert.match(source, /const \[savedPayloadKey, setSavedPayloadKey\]/)
+  assert.match(source, /const showSavedStatus =\s*saveStatus === 'success' &&\s*currentPayloadKey !== null &&\s*currentPayloadKey === savedPayloadKey/)
+  assert.match(source, /setSaveStatus\(\(status\) => \(status === 'loading' \? status : 'idle'\)\)/)
+  assert.match(source, /onSelect=\{\(id\) => updateSelectedSlot\(activeSlot!, id\)\}/)
+})

--- a/src/components/picks/PickHero.tsx
+++ b/src/components/picks/PickHero.tsx
@@ -56,6 +56,15 @@ function parsePendingPick(raw: string | null, raceId: string): PickPayload | nul
   }
 }
 
+function serializePickPayload(payload: PickPayload): string {
+  return JSON.stringify([
+    payload.raceId,
+    payload.tenthPlaceDriverId,
+    payload.winnerDriverId,
+    payload.dnfDriverId,
+  ])
+}
+
 // ─── Pick bubble ─────────────────────────────────────────────────────────────
 
 function PickBubble({
@@ -320,6 +329,7 @@ export function PickHero({
   const [activeSlot, setActiveSlot] = useState<Slot | null>(null)
   const [saveStatus, setSaveStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle')
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
+  const [savedPayloadKey, setSavedPayloadKey] = useState<string | null>(null)
 
   const driverById = Object.fromEntries(entrants.map((d) => [d.id, d]))
 
@@ -350,6 +360,12 @@ export function PickHero({
       dnfDriverId: pickState.dnf,
     }
   }, [race.id])
+  const currentPayload = buildPickPayload(selected)
+  const currentPayloadKey = currentPayload ? serializePickPayload(currentPayload) : null
+  const showSavedStatus =
+    saveStatus === 'success' &&
+    currentPayloadKey !== null &&
+    currentPayloadKey === savedPayloadKey
 
   const submitPickPayload = useCallback(async (payload: PickPayload) => {
     const res = await fetch('/api/picks', {
@@ -387,9 +403,12 @@ export function PickHero({
     setErrorMsg(null)
 
     let cancelled = false
+    const pendingPayloadKey = serializePickPayload(pendingPick)
     submitPickPayload(pendingPick)
       .then(() => {
-        if (!cancelled) setSaveStatus('success')
+        if (cancelled) return
+        setSavedPayloadKey(pendingPayloadKey)
+        setSaveStatus('success')
       })
       .catch((err) => {
         if (cancelled) return
@@ -402,9 +421,18 @@ export function PickHero({
     }
   }, [existingPick, isLocked, race.id, requiresSignIn, submitPickPayload])
 
+  const updateSelectedSlot = useCallback((slot: Slot, id: string | null) => {
+    setSelected((prev) => {
+      if (prev[slot] === id) return prev
+      return { ...prev, [slot]: id }
+    })
+    setSaveStatus((status) => (status === 'loading' ? status : 'idle'))
+    setErrorMsg(null)
+  }, [])
+
   const handleSave = async () => {
     if (!canSave) return
-    const payload = buildPickPayload(selected)
+    const payload = currentPayload
     if (!payload) return
 
     if (requiresSignIn) {
@@ -421,6 +449,7 @@ export function PickHero({
 
     try {
       await submitPickPayload(payload)
+      setSavedPayloadKey(serializePickPayload(payload))
       setSaveStatus('success')
     } catch (err) {
       setSaveStatus('error')
@@ -549,7 +578,7 @@ export function PickHero({
           {saveStatus === 'error' && errorMsg && (
             <p className="text-sm text-accent text-center">{errorMsg}</p>
           )}
-          {saveStatus === 'success' && (
+          {showSavedStatus && (
             <div className="flex items-center justify-center gap-1.5 text-success text-sm font-medium">
               <CheckCircle2 className="w-4 h-4" />
               Picks saved!
@@ -586,7 +615,7 @@ export function PickHero({
           entrants={entrants}
           disabledIds={disabledForSlot(activeSlot)}
           selectedId={selected[activeSlot]}
-          onSelect={(id) => setSelected((prev) => ({ ...prev, [activeSlot!]: id }))}
+          onSelect={(id) => updateSelectedSlot(activeSlot!, id)}
           onClose={() => setActiveSlot(null)}
         />
       )}


### PR DESCRIPTION
Closes #167

## Summary
- hide saved feedback unless the current selections match the last successfully saved payload
- clear non-loading save feedback and errors when a local slot selection changes
- add a PickHero regression guard for stale saved feedback

## Test Plan
- [x] `npm run test:components`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npx tsc --noEmit` after build regenerated `.next/types`

— gib