### PR TITLE
Scope segmented control layout ids

### DIFF
--- a/src/components/ui/segmented-control.test.mjs
+++ b/src/components/ui/segmented-control.test.mjs
@@ -8,3 +8,10 @@ test("SegmentedControl exposes selected button state to assistive technology", (
   assert.match(source, /role="group"/)
   assert.match(source, /aria-pressed=\{isActive\}/)
 })
+
+test("SegmentedControl scopes the active pill layout id per instance", () => {
+  assert.match(source, /React\.useId\(\)/)
+  assert.match(source, /const activePillLayoutId = `segmented-control-pill-\$\{controlId\}`/)
+  assert.match(source, /layoutId=\{activePillLayoutId\}/)
+  assert.doesNotMatch(source, /layoutId="segmented-control-pill"/)
+})

--- a/src/components/ui/segmented-control.tsx
+++ b/src/components/ui/segmented-control.tsx
@@ -23,6 +23,9 @@ export function SegmentedControl({
   onChange,
   className,
 }: SegmentedControlProps) {
+  const controlId = React.useId()
+  const activePillLayoutId = `segmented-control-pill-${controlId}`
+
   return (
     <div
       className={cn(
@@ -48,7 +51,7 @@ export function SegmentedControl({
             {/* Sliding indicator — sits behind label text */}
             {isActive && (
               <motion.span
-                layoutId="segmented-control-pill"
+                layoutId={activePillLayoutId}
                 className="absolute inset-0 rounded-full bg-[rgba(0,0,0,0.07)] shadow-sm"
                 transition={{ type: 'spring', stiffness: 400, damping: 35 }}
               />


### PR DESCRIPTION
Closes #168

## Summary
- give each `SegmentedControl` instance its own stable active-pill layout id
- remove the shared Framer Motion layout id that could link unrelated controls
- add a regression guard for per-instance segmented-control layout ids

## Test Plan
- [x] `npm run test:components`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

— gib