### PR TITLE
Return team color style objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:ios": "node --test ios/project-signing.test.mjs ios/signin-view-model.test.mjs ios/diagnostics-entry.test.mjs ios/profile-refresh-key.test.mjs ios/races-list-ordering.test.mjs",
     "test:ios-config": "node --test ios/project-signing.test.mjs",
     "test:pages": "node --test 'src/app/(main)/races/race-detail-page.test.mjs' 'src/app/(auth)/onboarding/username/page.test.mjs' 'src/app/(main)/leaderboard/search-params.test.mjs'",
+    "test:utils": "node --test src/lib/utils.test.mjs",
     "test:scoring": "node --test src/lib/scoring/formula.test.mjs",
     "test:scripts": "node --test scripts/find-cheated-picks.test.mjs scripts/tsconfig-prisma-coverage.test.mjs",
     "test:services": "node --test src/lib/services/race.service.test.mjs src/lib/services/leaderboard-rank.test.mjs src/lib/services/friendship.service.test.mjs",

--- a/src/lib/utils.test.mjs
+++ b/src/lib/utils.test.mjs
@@ -1,0 +1,12 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const source = await readFile(new URL("./utils.ts", import.meta.url), "utf8")
+
+test("team color helper returns a React-compatible color style object", () => {
+  assert.match(source, /export function getTeamColorStyle\(hex: string\): \{ color: string \}/)
+  assert.match(source, /return \{ color: normalized \}/)
+  assert.doesNotMatch(source, /return `color: \$\{normalized\}`/)
+  assert.doesNotMatch(source, /getTeamColorClass/)
+})

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -61,15 +61,15 @@ export function msToCountdown(ms: number): string {
 // ─────────────────────────────────────────────
 
 /**
- * Return an inline CSS `color` style string for a team color hex value.
+ * Return an inline CSS `color` style object for a team color hex value.
  *
  * Usage in JSX: `<span style={{ ...getTeamColorStyle('#E8002D') }}>`
  *
  * @param hex - Full hex string with or without '#' prefix
  */
-export function getTeamColorClass(hex: string): string {
+export function getTeamColorStyle(hex: string): { color: string } {
   const normalized = hex.startsWith('#') ? hex : `#${hex}`
-  return `color: ${normalized}`
+  return { color: normalized }
 }
 
 /**


### PR DESCRIPTION
Closes #170

## Summary
- rename the team color helper to match its documented inline-style usage
- return a React-compatible `{ color }` object instead of a CSS declaration string
- add a focused utility test command for the helper contract

## Test Plan
- [x] `npm run test:utils`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

— gib