### PR TITLE
Document Vercel CLI version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 
 ## Getting Started
 
+Install dependencies:
+
+```bash
+npm install
+```
+
+Use Vercel CLI 54.14.2 or newer for deployment-related local commands:
+
+```bash
+npm i -g vercel@latest
+vercel --version
+```
+
+This was last verified with Vercel CLI 54.14.5.
+
 First, run the development server:
 
 ```bash
@@ -32,5 +47,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 ## Deploy on Vercel
 
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+
+Scheduled jobs are not Vercel Cron jobs. See `ai/docs/cron-operations.md` for the AWS Lambda/EventBridge runbook.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.

--- a/ai/docs/architecture.md
+++ b/ai/docs/architecture.md
@@ -168,6 +168,7 @@ npm run build        # production build
 npm run lint         # ESLint
 npm run db:push      # sync Prisma schema (no migrations)
 npm run db:studio    # Prisma Studio GUI
+vercel --version     # local Vercel CLI should be 54.14.2 or newer
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:pages": "node --test 'src/app/(main)/races/race-detail-page.test.mjs' 'src/app/(auth)/onboarding/username/page.test.mjs' 'src/app/(main)/leaderboard/search-params.test.mjs'",
     "test:utils": "node --test src/lib/utils.test.mjs",
     "test:scoring": "node --test src/lib/scoring/formula.test.mjs",
-    "test:scripts": "node --test scripts/find-cheated-picks.test.mjs scripts/tsconfig-prisma-coverage.test.mjs",
+    "test:scripts": "node --test scripts/find-cheated-picks.test.mjs scripts/tsconfig-prisma-coverage.test.mjs scripts/vercel-cli-doc.test.mjs",
     "test:services": "node --test src/lib/services/race.service.test.mjs src/lib/services/leaderboard-rank.test.mjs src/lib/services/friendship.service.test.mjs",
     "lint": "next lint",
     "db:push": "prisma db push",

--- a/scripts/vercel-cli-doc.test.mjs
+++ b/scripts/vercel-cli-doc.test.mjs
@@ -1,0 +1,11 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const readme = await readFile(new URL("../README.md", import.meta.url), "utf8")
+
+test("README documents the expected Vercel CLI version", () => {
+  assert.match(readme, /Vercel CLI 54\.14\.2 or newer/)
+  assert.match(readme, /npm i -g vercel@latest/)
+  assert.match(readme, /vercel --version/)
+})


### PR DESCRIPTION
Closes #181

## Summary
- upgrade the local Vercel CLI used in this environment to 54.14.5
- document the expected Vercel CLI minimum version in setup docs and shared architecture notes
- add a script-level regression test that keeps the README tooling note in place

## Test Plan
- [x] `vercel --version` -> `54.14.5`
- [x] `npm run test:scripts`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

— gib