### PR TITLE
Add PR verification workflow and env template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,28 @@
+# Copy to .env.local for local development. Never commit real secrets.
+
+# PostgreSQL / Prisma
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/f10_fantasy?schema=public"
+DIRECT_URL="postgresql://postgres:postgres@localhost:5432/f10_fantasy?schema=public"
+
+# Auth.js and mobile JWT signing
+AUTH_SECRET="replace-with-openssl-rand-base64-32"
+
+# Cron and diagnostic routes
+CRON_SECRET="replace-with-random-cron-secret"
+
+# Google OAuth
+GOOGLE_CLIENT_ID="replace-with-google-web-client-id"
+GOOGLE_CLIENT_SECRET="replace-with-google-web-client-secret"
+GOOGLE_IOS_CLIENT_ID="replace-with-google-ios-client-id"
+
+# Apple OAuth / native Sign in with Apple
+APPLE_ID="replace-with-apple-service-id"
+APPLE_SECRET="replace-with-apple-client-secret"
+APPLE_BUNDLE_ID="com.fxracing.app"
+
+# Optional: use a dedicated key for stored OAuth token encryption.
+# If unset, AUTH_SECRET is used.
+ACCOUNT_TOKEN_ENCRYPTION_KEY=""
+
+# Optional: override OpenF1 for local testing.
+OPENF1_BASE_URL="https://api.openf1.org/v1"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,64 @@
+name: Verify
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  web:
+    name: Web checks
+    runs-on: ubuntu-latest
+    env:
+      NEXT_TELEMETRY_DISABLED: "1"
+      DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/f10_fantasy_ci?schema=public"
+      DIRECT_URL: "postgresql://postgres:postgres@localhost:5432/f10_fantasy_ci?schema=public"
+      AUTH_SECRET: "ci-only-auth-secret-replace-in-real-envs"
+      CRON_SECRET: "ci-only-cron-secret"
+      GOOGLE_CLIENT_ID: "ci-google-client-id"
+      GOOGLE_CLIENT_SECRET: "ci-google-client-secret"
+      GOOGLE_IOS_CLIENT_ID: "ci-google-ios-client-id"
+      APPLE_ID: "ci.apple.service.id"
+      APPLE_SECRET: "ci-apple-client-secret"
+      APPLE_BUNDLE_ID: "com.fxracing.app"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Run tests
+        run: |
+          npm run test:auth
+          npm run test:db
+          npm run test:routes
+          npm run test:services
+          npm run test:components
+          npm run test:ios
+          npm run test:pages
+          npm run test:utils
+          npm run test:scoring
+          npm run test:scripts
+          npx tsx scripts/test-mobile-provider-email.ts
+          npx tsx scripts/test-mobile-exchange-race-guards.ts
+
+      - name: Build
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ Install dependencies:
 npm install
 ```
 
+Create a local environment file:
+
+```bash
+cp .env.example .env.local
+```
+
+Fill `.env.local` with development credentials. Do not commit real secrets.
+
 Use Vercel CLI 54.14.2 or newer for deployment-related local commands:
 
 ```bash
@@ -31,7 +39,7 @@ bun dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+You can start editing the page by modifying files under `src/app`. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
 


### PR DESCRIPTION
Closes #234

## Summary
- add a GitHub Actions verification workflow for PRs and main pushes
- document safe local/CI environment placeholders in `.env.example`
- point README setup at `.env.example` and fix the stale `app/page.tsx` path

## Test Plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run test:auth`
- [x] `npm run test:db`
- [x] `npm run test:routes`
- [x] `npm run test:services`
- [x] `npm run test:components`
- [x] `npm run test:ios`
- [x] `npm run test:pages`
- [x] `npm run test:utils`
- [x] `npm run test:scoring`
- [x] `npm run test:scripts`
- [x] `npx tsx scripts/test-mobile-provider-email.ts`
- [x] `npx tsx scripts/test-mobile-exchange-race-guards.ts`
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/verify.yml"); puts "workflow yaml parse ok"'`\n- [x] `npm run build`\n\n— gib