### PR TITLE
Remove mobile auth token claim logging

### DIFF
--- a/src/lib/auth/mobileAuth.ts
+++ b/src/lib/auth/mobileAuth.ts
@@ -41,7 +41,6 @@ export async function mobileAuth(req: Request): Promise<Session | null> {
   }
 
   const userId = (payload.id ?? payload.sub) as string | undefined
-  console.log('[mobileAuth] token keys:', Object.keys(payload), 'userId:', userId)
   if (!userId) return null
   if (typeof payload.exp !== 'number') return null
 


### PR DESCRIPTION
Closes #236

## Summary
- remove the success-path mobile auth log that printed JWT claim keys and user id
- keep invalid-token verification failures visible without logging token contents

## Test Plan
- [x] `npm run test:auth`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `rg -n "token keys|Object\.keys\(payload\).*userId|\[mobileAuth\]" src/lib/auth/mobileAuth.ts`

— gib