### PR TITLE
Capture redacted browser errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:ios": "node --test ios/project-signing.test.mjs ios/signin-view-model.test.mjs ios/diagnostics-entry.test.mjs ios/profile-refresh-key.test.mjs ios/races-list-ordering.test.mjs",
     "test:ios-config": "node --test ios/project-signing.test.mjs",
     "test:pages": "node --test 'src/app/(main)/races/race-detail-page.test.mjs' 'src/app/(auth)/onboarding/username/page.test.mjs' 'src/app/(main)/leaderboard/search-params.test.mjs'",
-    "test:utils": "node --test src/lib/utils.test.mjs",
+    "test:utils": "node --test src/lib/utils.test.mjs src/lib/observability/client-errors.test.mjs",
     "test:scoring": "node --test src/lib/scoring/formula.test.mjs",
     "test:scripts": "node --test scripts/find-cheated-picks.test.mjs scripts/tsconfig-prisma-coverage.test.mjs scripts/vercel-cli-doc.test.mjs",
     "test:services": "node --test src/lib/services/race.service.test.mjs src/lib/services/leaderboard-rank.test.mjs src/lib/services/friendship.service.test.mjs",

--- a/src/app/api/client-errors/route.ts
+++ b/src/app/api/client-errors/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server"
+import { sanitizeClientErrorPayload } from "@/lib/observability/client-errors"
+
+export const dynamic = "force-dynamic"
+
+export async function POST(request: Request) {
+  let body: unknown
+
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+  }
+
+  const event = sanitizeClientErrorPayload(body)
+  if (!event) {
+    return NextResponse.json(
+      { error: "Invalid client error payload" },
+      { status: 400 },
+    )
+  }
+
+  console.error("[f10:client-error]", event)
+
+  return NextResponse.json({ ok: true })
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,6 +1,7 @@
 'use client';
  
 import { useEffect } from 'react';
+import { reportClientError } from '@/lib/observability/report-client-error';
  
 export default function Error({
   error,
@@ -10,8 +11,11 @@ export default function Error({
   reset: () => void;
 }) {
   useEffect(() => {
-    // Optionally log the error to an error reporting service
-    console.error(error);
+    reportClientError({
+      kind: 'boundary',
+      message: error.message || 'Client error boundary',
+      digest: error.digest,
+    });
   }, [error]);
  
   return (

--- a/src/components/ClientErrorReporter.tsx
+++ b/src/components/ClientErrorReporter.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { useEffect } from "react"
+import {
+  messageFromUnknown,
+  reportClientError,
+} from "@/lib/observability/report-client-error"
+
+export function ClientErrorReporter() {
+  useEffect(() => {
+    const onError = (event: ErrorEvent) => {
+      reportClientError({
+        kind: "error",
+        message: event.error
+          ? messageFromUnknown(event.error)
+          : event.message || "Unhandled client error",
+      })
+    }
+
+    const onUnhandledRejection = (event: PromiseRejectionEvent) => {
+      reportClientError({
+        kind: "unhandledrejection",
+        message: messageFromUnknown(event.reason),
+      })
+    }
+
+    window.addEventListener("error", onError)
+    window.addEventListener("unhandledrejection", onUnhandledRejection)
+
+    return () => {
+      window.removeEventListener("error", onError)
+      window.removeEventListener("unhandledrejection", onUnhandledRejection)
+    }
+  }, [])
+
+  return null
+}

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -3,6 +3,7 @@
 import { SessionProvider, useSession } from "next-auth/react"
 import { useRouter } from "next/navigation"
 import { useEffect, useRef } from "react"
+import { ClientErrorReporter } from "./ClientErrorReporter"
 import { shouldRefreshForSessionStatus } from "./session-sync"
 
 /**
@@ -29,6 +30,7 @@ function SessionSync() {
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <SessionProvider>
+      <ClientErrorReporter />
       <SessionSync />
       {children}
     </SessionProvider>

--- a/src/lib/observability/client-errors.js
+++ b/src/lib/observability/client-errors.js
@@ -1,0 +1,92 @@
+const MAX_TEXT_LENGTH = 500
+const MAX_PATH_LENGTH = 200
+const MAX_DIGEST_LENGTH = 120
+const VALID_KINDS = new Set(["boundary", "error", "unhandledrejection"])
+
+const BEARER_TOKEN_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi
+const JWT_PATTERN =
+  /\b[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g
+const EMAIL_PATTERN = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi
+const UUID_PATTERN =
+  /\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/gi
+const SECRET_ASSIGNMENT_PATTERN =
+  /\b(access_token|api[_-]?key|id_token|password|refresh_token|secret|token)=([^&\s]+)/gi
+
+function stringifyText(value) {
+  if (typeof value === "string") {
+    return value
+  }
+
+  if (value instanceof Error) {
+    return value.message
+  }
+
+  try {
+    const json = JSON.stringify(value)
+    return json ?? String(value ?? "")
+  } catch {
+    return String(value ?? "")
+  }
+}
+
+function limitText(value, maxLength) {
+  return value.slice(0, maxLength)
+}
+
+function sanitizePath(value) {
+  if (typeof value !== "string") {
+    return "unknown"
+  }
+
+  const trimmed = value.trim()
+  if (!trimmed.startsWith("/")) {
+    return "unknown"
+  }
+
+  const path = trimmed.split(/[?#]/, 1)[0] || "/"
+  if (!path.startsWith("/") || /\s/.test(path)) {
+    return "unknown"
+  }
+
+  return limitText(path, MAX_PATH_LENGTH)
+}
+
+function redactClientErrorText(value) {
+  return limitText(
+    stringifyText(value)
+      .replace(BEARER_TOKEN_PATTERN, "Bearer [redacted-token]")
+      .replace(JWT_PATTERN, "[redacted-jwt]")
+      .replace(EMAIL_PATTERN, "[redacted-email]")
+      .replace(UUID_PATTERN, "[redacted-id]")
+      .replace(SECRET_ASSIGNMENT_PATTERN, "$1=[redacted-secret]"),
+    MAX_TEXT_LENGTH,
+  )
+}
+
+function sanitizeClientErrorPayload(body) {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return null
+  }
+
+  const message = redactClientErrorText(body.message).trim()
+  if (!message) {
+    return null
+  }
+
+  const kind = VALID_KINDS.has(body.kind) ? body.kind : "error"
+  const event = {
+    kind,
+    message,
+    path: sanitizePath(body.path),
+  }
+
+  const digest = redactClientErrorText(body.digest).trim()
+  if (digest) {
+    event.digest = limitText(digest, MAX_DIGEST_LENGTH)
+  }
+
+  return event
+}
+
+exports.redactClientErrorText = redactClientErrorText
+exports.sanitizeClientErrorPayload = sanitizeClientErrorPayload

--- a/src/lib/observability/client-errors.test.mjs
+++ b/src/lib/observability/client-errors.test.mjs
@@ -1,0 +1,50 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+
+import {
+  redactClientErrorText,
+  sanitizeClientErrorPayload,
+} from "./client-errors.js"
+
+test("redacts obvious sensitive values from client error text", () => {
+  const jwt =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyLTEyMyIsImVtYWlsIjoidGVzdEBleGFtcGxlLmNvbSJ9.abcdefghijklmnopqrstuvwxyz"
+  const source = `Failed for user test@example.com with Bearer ${jwt} at 3f7ef00d-2f57-4f28-94ec-5c7db018a0db`
+
+  const redacted = redactClientErrorText(source)
+
+  assert.doesNotMatch(redacted, /test@example\.com/)
+  assert.doesNotMatch(redacted, new RegExp(jwt.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")))
+  assert.doesNotMatch(redacted, /3f7ef00d-2f57-4f28-94ec-5c7db018a0db/)
+  assert.match(redacted, /\[redacted-email\]/)
+  assert.match(redacted, /Bearer \[redacted-token\]/)
+  assert.match(redacted, /\[redacted-id\]/)
+})
+
+test("limits client error text length", () => {
+  const redacted = redactClientErrorText("x".repeat(900))
+
+  assert.equal(redacted.length, 500)
+})
+
+test("sanitizes client error payloads without query strings", () => {
+  const event = sanitizeClientErrorPayload({
+    kind: "unhandledrejection",
+    message: "Fetch failed for person@example.com",
+    path: "/races/1?token=secret#details",
+    digest: "digest-3f7ef00d-2f57-4f28-94ec-5c7db018a0db",
+  })
+
+  assert.deepEqual(event, {
+    kind: "unhandledrejection",
+    message: "Fetch failed for [redacted-email]",
+    path: "/races/1",
+    digest: "digest-[redacted-id]",
+  })
+})
+
+test("rejects invalid client error payloads", () => {
+  assert.equal(sanitizeClientErrorPayload(null), null)
+  assert.equal(sanitizeClientErrorPayload([]), null)
+  assert.equal(sanitizeClientErrorPayload({ message: "" }), null)
+})

--- a/src/lib/observability/report-client-error.ts
+++ b/src/lib/observability/report-client-error.ts
@@ -1,0 +1,63 @@
+"use client"
+
+type ClientErrorKind = "boundary" | "error" | "unhandledrejection"
+
+type ClientErrorReport = {
+  kind: ClientErrorKind
+  message: string
+  digest?: string
+}
+
+function stringifyUnknown(value: unknown): string {
+  if (value instanceof Error) {
+    return value.message || value.name
+  }
+
+  if (typeof value === "string") {
+    return value
+  }
+
+  try {
+    return JSON.stringify(value) ?? "Client error"
+  } catch {
+    return "Client error"
+  }
+}
+
+export function messageFromUnknown(value: unknown): string {
+  return stringifyUnknown(value).trim() || "Client error"
+}
+
+export function reportClientError(report: ClientErrorReport) {
+  if (typeof window === "undefined") {
+    return
+  }
+
+  const body = JSON.stringify({
+    kind: report.kind,
+    message: report.message.trim() || "Client error",
+    digest: report.digest,
+    path: window.location.pathname,
+  })
+
+  try {
+    if (typeof navigator !== "undefined" && navigator.sendBeacon) {
+      const sent = navigator.sendBeacon(
+        "/api/client-errors",
+        new Blob([body], { type: "application/json" }),
+      )
+      if (sent) {
+        return
+      }
+    }
+
+    void fetch("/api/client-errors", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+      keepalive: true,
+    }).catch(() => undefined)
+  } catch {
+    // Reporting must never create another visible client error.
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -30,6 +30,10 @@ const API_PREFIX = "/api";
 type NextAuthRequest = NextRequest & { auth: Session | null };
 
 function isPublicApiRoute(pathname: string, method: string): boolean {
+  if (pathname === "/api/client-errors") {
+    return method === "POST";
+  }
+
   if (pathname === "/api/races" || pathname.startsWith("/api/races/")) {
     return method === "GET";
   }


### PR DESCRIPTION
Closes #238

## Summary
- add a public `POST /api/client-errors` endpoint that logs sanitized client error events
- mount a browser reporter for `error`, `unhandledrejection`, and Next error-boundary failures
- redact obvious emails, bearer/JWT tokens, UUIDs, and secret-looking assignments while stripping query strings from paths

## Test Plan
- [x] `npm run test:utils`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

— gib