### PR TITLE
Cover OpenF1 DNS classification

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:utils": "node --test src/lib/utils.test.mjs src/lib/observability/client-errors.test.mjs",
     "test:scoring": "node --test src/lib/scoring/formula.test.mjs",
     "test:scripts": "node --test scripts/find-cheated-picks.test.mjs scripts/tsconfig-prisma-coverage.test.mjs scripts/vercel-cli-doc.test.mjs",
-    "test:services": "node --test src/lib/services/race.service.test.mjs src/lib/services/leaderboard-rank.test.mjs src/lib/services/friendship.service.test.mjs",
+    "test:services": "node --test src/lib/services/race.service.test.mjs src/lib/services/leaderboard-rank.test.mjs src/lib/services/friendship.service.test.mjs src/lib/f1/providers/openf1.test.mjs",
     "lint": "next lint",
     "db:push": "prisma db push",
     "db:studio": "prisma studio",

--- a/src/lib/f1/providers/openf1.test.mjs
+++ b/src/lib/f1/providers/openf1.test.mjs
@@ -1,0 +1,100 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import ts from "typescript"
+
+async function loadOpenF1Module() {
+  const source = await readFile(new URL("./openf1.ts", import.meta.url), "utf8")
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2022,
+    },
+  })
+  const encoded = Buffer.from(outputText).toString("base64")
+  return import(`data:text/javascript;base64,${encoded}`)
+}
+
+const { OpenF1Provider } = await loadOpenF1Module()
+
+function jsonResponse(data) {
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  })
+}
+
+test("getFinalResults distinguishes DNS drivers from DNF retirements", async () => {
+  const previousFetch = globalThis.fetch
+  globalThis.fetch = async (url) => {
+    const requestUrl = String(url)
+
+    if (requestUrl.endsWith("/position?session_key=123")) {
+      return jsonResponse([
+        {
+          session_key: 123,
+          driver_number: 1,
+          position: 1,
+          date: "2026-06-21T15:00:00.000Z",
+        },
+        {
+          session_key: 123,
+          driver_number: 2,
+          position: 2,
+          date: "2026-06-21T15:00:00.000Z",
+        },
+        {
+          session_key: 123,
+          driver_number: 3,
+          position: 3,
+          date: "2026-06-21T15:00:00.000Z",
+        },
+        {
+          session_key: 123,
+          driver_number: 4,
+          position: 4,
+          date: "2026-06-21T15:00:00.000Z",
+        },
+      ])
+    }
+
+    if (requestUrl.endsWith("/stints?session_key=123")) {
+      return jsonResponse([
+        { session_key: 123, driver_number: 1, lap_start: 1, lap_end: 10 },
+        { session_key: 123, driver_number: 2, lap_start: 1, lap_end: 9 },
+        { session_key: 123, driver_number: 3, lap_start: 1, lap_end: 7 },
+      ])
+    }
+
+    return new Response("not found", { status: 404, statusText: "Not Found" })
+  }
+
+  try {
+    const provider = new OpenF1Provider()
+    const results = await provider.getFinalResults(123)
+    const byDriver = new Map(results.map((r) => [r.driverNumber, r]))
+
+    assert.deepEqual(byDriver.get(1), {
+      driverNumber: 1,
+      position: 1,
+      status: "CLASSIFIED",
+    })
+    assert.deepEqual(byDriver.get(2), {
+      driverNumber: 2,
+      position: 2,
+      status: "CLASSIFIED",
+    })
+    assert.deepEqual(byDriver.get(3), {
+      driverNumber: 3,
+      position: null,
+      status: "DNF",
+    })
+    assert.deepEqual(byDriver.get(4), {
+      driverNumber: 4,
+      position: null,
+      status: "DNS",
+    })
+  } finally {
+    globalThis.fetch = previousFetch
+  }
+})


### PR DESCRIPTION
Closes #242

## Summary
- add a fixture-backed OpenF1 provider test for final result classification
- assert drivers with position data but no stint rows are emitted as `DNS`
- assert drivers below the 90% lap threshold remain `DNF`

## Test Plan
- [x] `npm run test:services`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

— gib