### PR TITLE
Cover iOS race detail load reset

### DIFF
--- a/ios/race-detail-load-reset.test.mjs
+++ b/ios/race-detail-load-reset.test.mjs
@@ -1,0 +1,59 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const source = await readFile(
+  new URL("./FXRacing/Features/Races/RaceDetailViewModel.swift", import.meta.url),
+  "utf8",
+)
+
+const loadBlock = source.match(/func load\(token:[\s\S]*?\n    \}/)?.[0]
+
+test("RaceDetailViewModel leaves detail-load failures visible for retry", () => {
+  assert.ok(loadBlock, "load(token:localPickStore:) should exist")
+  assert.match(
+    loadBlock,
+    /catch \{\s*errorMessage = error\.localizedDescription[\s\S]*return\s*\}/,
+    "detail request failures should set the retry error and stop before clearing state",
+  )
+})
+
+test("RaceDetailViewModel clears stale pick state after a successful detail load", () => {
+  assert.ok(loadBlock, "load(token:localPickStore:) should exist")
+
+  const successIndex = loadBlock.indexOf("let detail: DetailResponse = try await")
+  const resetIndex = loadBlock.indexOf("errorMessage = nil")
+  const serverPickIndex = loadBlock.indexOf("// Populate selections: server pick takes precedence")
+  const localFallbackIndex = loadBlock.indexOf("// Fall back to local pick")
+
+  assert.notEqual(successIndex, -1, "successful detail request should be present")
+  assert.notEqual(resetIndex, -1, "successful load should clear stale state")
+  assert.notEqual(serverPickIndex, -1, "server pick fallback should be present")
+  assert.notEqual(localFallbackIndex, -1, "local pick fallback should be present")
+  assert.ok(successIndex < resetIndex, "reset should run only after detail succeeds")
+  assert.ok(resetIndex < serverPickIndex, "reset should run before server pick repopulation")
+  assert.ok(resetIndex < localFallbackIndex, "reset should run before local pick repopulation")
+
+  const resetBlock = loadBlock.slice(resetIndex, serverPickIndex)
+  for (const reset of [
+    "errorMessage = nil",
+    "serverPick = nil",
+    "isLocalOnly = false",
+    "selectedWinner = nil",
+    "selectedP10 = nil",
+    "selectedDNF = nil",
+  ]) {
+    assert.match(resetBlock, new RegExp(reset.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")))
+  }
+})
+
+test("RaceDetailViewModel still repopulates selections from a local pick after reset", () => {
+  assert.ok(loadBlock, "load(token:localPickStore:) should exist")
+
+  const localBlock = loadBlock.match(/\/\/ Fall back to local pick[\s\S]*?selectedDNF\s*=.*\n        \}/)?.[0]
+  assert.ok(localBlock, "local pick fallback should exist")
+  assert.match(localBlock, /isLocalOnly = !local\.synced/)
+  assert.match(localBlock, /selectedWinner = entrants\.first \{ \$0\.id == local\.winnerId \}/)
+  assert.match(localBlock, /selectedP10\s*= entrants\.first \{ \$0\.id == local\.p10Id \}/)
+  assert.match(localBlock, /selectedDNF\s*= entrants\.first \{ \$0\.id == local\.dnfId \}/)
+})

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:auth": "node --test src/auth-callbacks.test.mjs src/lib/auth/session-cutoff.test.mjs src/lib/auth/cronPath.test.mjs src/lib/auth/mobileAuth.test.mjs src/lib/security/account-token-crypto.test.mjs",
     "test:db": "node --test src/lib/db/token-field-transform.test.mjs",
     "test:components": "node --test src/components/ui/segmented-control.test.mjs 'src/app/(main)/profile/profile-async-guards.test.mjs' 'src/app/(main)/UserAvatarMenu.test.mjs' src/components/picks/PickHero.test.mjs src/components/picks/PicksDisplay.test.mjs src/components/legal/LegalModal.test.mjs src/components/session-sync.test.mjs src/components/race/lock-countdown-timer.test.mjs src/components/race/HeroVisualization.test.mjs src/components/race/RaceResultsCard.test.mjs",
-    "test:ios": "node --test ios/project-signing.test.mjs ios/signin-view-model.test.mjs ios/diagnostics-entry.test.mjs ios/profile-refresh-key.test.mjs ios/races-list-ordering.test.mjs",
+    "test:ios": "node --test ios/project-signing.test.mjs ios/signin-view-model.test.mjs ios/diagnostics-entry.test.mjs ios/profile-refresh-key.test.mjs ios/races-list-ordering.test.mjs ios/race-detail-load-reset.test.mjs",
     "test:ios-config": "node --test ios/project-signing.test.mjs",
     "test:pages": "node --test 'src/app/(main)/races/race-detail-page.test.mjs' 'src/app/(auth)/onboarding/username/page.test.mjs' 'src/app/(main)/leaderboard/search-params.test.mjs'",
     "test:utils": "node --test src/lib/utils.test.mjs src/lib/observability/client-errors.test.mjs",


### PR DESCRIPTION
Closes #254

## Summary
- add an iOS source regression for RaceDetailViewModel load retry/reset behavior
- assert successful detail reloads clear stale error, server pick, local-only, and selected driver state before repopulating
- wire the regression into `npm run test:ios`

## Test Plan
- [x] `node --test ios/race-detail-load-reset.test.mjs`
- [x] red/green: temporarily removed `serverPick = nil`, verified the new test failed, restored it and verified it passed
- [x] `npm run test:ios`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `cd ios && xcodebuild -project FXRacing.xcodeproj -scheme FXRacing -destination 'generic/platform=iOS Simulator' -derivedDataPath /private/tmp/f10-fantasy-xcodebuild build`\n- [x] `npm run build`\n\n— gib