### PR TITLE
Cover iOS guest leaderboard access

### DIFF
--- a/ios/leaderboard-guest-access.test.mjs
+++ b/ios/leaderboard-guest-access.test.mjs
@@ -1,0 +1,43 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const source = await readFile(
+  new URL("./FXRacing/Features/Rankings/LeaderboardView.swift", import.meta.url),
+  "utf8",
+)
+
+test("LeaderboardView loads global rankings for signed-out users", () => {
+  const loadBlock = source.match(/private func loadIfAllowed\(\) async \{[\s\S]*?\n    \}/)?.[0]
+
+  assert.ok(loadBlock, "loadIfAllowed should exist")
+  assert.match(
+    loadBlock,
+    /guard vm\.scope == \.global \|\| authManager\.isAuthenticated else \{ return \}/,
+    "global scope should be allowed without authentication",
+  )
+  assert.doesNotMatch(
+    loadBlock,
+    /guard authManager\.isAuthenticated else \{ return \}/,
+    "a blanket auth guard would make global rankings unreachable for guests",
+  )
+  assert.match(loadBlock, /await vm\.load\(token: authManager\.accessToken\)/)
+})
+
+test("LeaderboardView only gates Friends ranking UI behind sign-in", () => {
+  assert.match(
+    source,
+    /if vm\.scope == \.friends && !authManager\.isAuthenticated \{[\s\S]*Text\("Sign in to view friends"\)/,
+    "the signed-out empty state should only apply to the Friends scope",
+  )
+  assert.doesNotMatch(
+    source,
+    /if !authManager\.isAuthenticated \{[\s\S]*Text\("Sign in to view friends"\)/,
+    "global rankings should not enter the Friends sign-in branch",
+  )
+  assert.match(
+    source,
+    /if vm\.scope == \.friends \{[\s\S]*ToolbarItem\(placement: \.topBarTrailing\)/,
+    "friend search actions should remain scoped to Friends",
+  )
+})

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:auth": "node --test src/auth-callbacks.test.mjs src/lib/auth/session-cutoff.test.mjs src/lib/auth/cronPath.test.mjs src/lib/auth/mobileAuth.test.mjs src/lib/security/account-token-crypto.test.mjs",
     "test:db": "node --test src/lib/db/token-field-transform.test.mjs",
     "test:components": "node --test src/components/ui/segmented-control.test.mjs 'src/app/(main)/profile/profile-async-guards.test.mjs' 'src/app/(main)/UserAvatarMenu.test.mjs' src/components/picks/PickHero.test.mjs src/components/picks/PicksDisplay.test.mjs src/components/legal/LegalModal.test.mjs src/components/session-sync.test.mjs src/components/race/lock-countdown-timer.test.mjs src/components/race/HeroVisualization.test.mjs src/components/race/RaceResultsCard.test.mjs",
-    "test:ios": "node --test ios/project-signing.test.mjs ios/signin-view-model.test.mjs ios/diagnostics-entry.test.mjs ios/profile-refresh-key.test.mjs ios/races-list-ordering.test.mjs ios/race-detail-load-reset.test.mjs",
+    "test:ios": "node --test ios/project-signing.test.mjs ios/signin-view-model.test.mjs ios/diagnostics-entry.test.mjs ios/profile-refresh-key.test.mjs ios/races-list-ordering.test.mjs ios/race-detail-load-reset.test.mjs ios/leaderboard-guest-access.test.mjs",
     "test:ios-config": "node --test ios/project-signing.test.mjs",
     "test:pages": "node --test 'src/app/(main)/races/race-detail-page.test.mjs' 'src/app/(auth)/onboarding/username/page.test.mjs' 'src/app/(main)/leaderboard/search-params.test.mjs'",
     "test:utils": "node --test src/lib/utils.test.mjs src/lib/observability/client-errors.test.mjs",


### PR DESCRIPTION
Closes #256

## Summary
- add an iOS source regression for signed-out Global leaderboard access
- assert Friends-only sign-in UI stays scoped to the Friends tab
- wire the regression into `npm run test:ios`

## Test Plan
- [x] `node --test ios/leaderboard-guest-access.test.mjs`
- [x] red/green: temporarily changed `loadIfAllowed` to a blanket auth guard, verified the test failed, restored the scope-aware guard and verified it passed
- [x] `npm run test:ios`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `cd ios && xcodebuild -project FXRacing.xcodeproj -scheme FXRacing -destination 'generic/platform=iOS Simulator' -derivedDataPath /private/tmp/f10-fantasy-xcodebuild build`\n- [x] `npm run build`\n\n— gib