### PR TITLE
Cover iOS leaderboard stale responses

### DIFF
--- a/ios/leaderboard-stale-response.test.mjs
+++ b/ios/leaderboard-stale-response.test.mjs
@@ -1,0 +1,58 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const source = await readFile(
+  new URL("./FXRacing/Features/Rankings/LeaderboardViewModel.swift", import.meta.url),
+  "utf8",
+)
+
+const loadBlock = source.match(/func load\(token:[\s\S]*?\n    \}/)?.[0]
+
+test("LeaderboardViewModel discards stale scope load responses", () => {
+  assert.ok(loadBlock, "load(token:) should exist")
+
+  assert.match(
+    source,
+    /private var loadGeneration = 0/,
+    "view model should track the latest leaderboard load generation",
+  )
+  assert.match(
+    source,
+    /var scope: Scope = \.global \{[\s\S]*didSet \{[\s\S]*guard oldValue != scope else \{ return \}[\s\S]*loadGeneration \+= 1[\s\S]*isLoading = false/,
+    "changing scope should invalidate any in-flight load and stop the stale loading state",
+  )
+
+  const generationIndex = loadBlock.indexOf("loadGeneration += 1")
+  const snapshotIndex = loadBlock.indexOf("let requestedScope = scope")
+  const requestIndex = loadBlock.indexOf(".leaderboard(scope: requestedScope.rawValue")
+  const successGuardIndex = loadBlock.indexOf("guard generation == loadGeneration, scope == requestedScope else { return }")
+  const rowsIndex = loadBlock.indexOf("rows = response.rows")
+  const catchIndex = loadBlock.indexOf("} catch {")
+  const errorGuardIndex = loadBlock.indexOf(
+    "guard generation == loadGeneration, scope == requestedScope else { return }",
+    catchIndex,
+  )
+  const errorIndex = loadBlock.indexOf("errorMessage = error.localizedDescription")
+  const loadingGuardIndex = loadBlock.indexOf("if generation == loadGeneration, scope == requestedScope")
+  const loadingDoneIndex = loadBlock.indexOf("isLoading = false", loadingGuardIndex)
+
+  assert.notEqual(generationIndex, -1, "load should reserve a generation before requesting")
+  assert.notEqual(snapshotIndex, -1, "load should snapshot the requested scope")
+  assert.notEqual(requestIndex, -1, "request should use the snapshotted scope")
+  assert.notEqual(successGuardIndex, -1, "successful responses should be guarded")
+  assert.notEqual(rowsIndex, -1, "successful responses should assign rows")
+  assert.notEqual(catchIndex, -1, "load should handle request failures")
+  assert.notEqual(errorGuardIndex, -1, "failed stale responses should be guarded")
+  assert.notEqual(errorIndex, -1, "current failed responses should assign the error")
+  assert.notEqual(loadingGuardIndex, -1, "loading cleanup should be guarded")
+  assert.notEqual(loadingDoneIndex, -1, "current load should clear loading")
+
+  assert.ok(generationIndex < requestIndex, "generation should be captured before the request")
+  assert.ok(snapshotIndex < requestIndex, "scope should be snapshotted before the request")
+  assert.ok(requestIndex < successGuardIndex, "success guard should run after the response")
+  assert.ok(successGuardIndex < rowsIndex, "rows should only update after stale-response guard")
+  assert.ok(catchIndex < errorGuardIndex, "error guard should run inside catch")
+  assert.ok(errorGuardIndex < errorIndex, "errors should only update after stale-response guard")
+  assert.ok(loadingGuardIndex < loadingDoneIndex, "loading state should only clear for the current load")
+})

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:auth": "node --test src/auth-callbacks.test.mjs src/lib/auth/session-cutoff.test.mjs src/lib/auth/cronPath.test.mjs src/lib/auth/mobileAuth.test.mjs src/lib/security/account-token-crypto.test.mjs",
     "test:db": "node --test src/lib/db/token-field-transform.test.mjs",
     "test:components": "node --test src/components/ui/segmented-control.test.mjs 'src/app/(main)/profile/profile-async-guards.test.mjs' 'src/app/(main)/UserAvatarMenu.test.mjs' src/components/picks/PickHero.test.mjs src/components/picks/PicksDisplay.test.mjs src/components/legal/LegalModal.test.mjs src/components/session-sync.test.mjs src/components/race/lock-countdown-timer.test.mjs src/components/race/HeroVisualization.test.mjs src/components/race/RaceResultsCard.test.mjs",
-    "test:ios": "node --test ios/project-signing.test.mjs ios/signin-view-model.test.mjs ios/diagnostics-entry.test.mjs ios/profile-refresh-key.test.mjs ios/races-list-ordering.test.mjs ios/race-detail-load-reset.test.mjs ios/leaderboard-guest-access.test.mjs",
+    "test:ios": "node --test ios/project-signing.test.mjs ios/signin-view-model.test.mjs ios/diagnostics-entry.test.mjs ios/profile-refresh-key.test.mjs ios/races-list-ordering.test.mjs ios/race-detail-load-reset.test.mjs ios/leaderboard-guest-access.test.mjs ios/leaderboard-stale-response.test.mjs",
     "test:ios-config": "node --test ios/project-signing.test.mjs",
     "test:pages": "node --test 'src/app/(main)/races/race-detail-page.test.mjs' 'src/app/(auth)/onboarding/username/page.test.mjs' 'src/app/(main)/leaderboard/search-params.test.mjs'",
     "test:utils": "node --test src/lib/utils.test.mjs src/lib/observability/client-errors.test.mjs",


### PR DESCRIPTION
Closes #258

## Summary
- add iOS source regression coverage for leaderboard load generation guards
- include the stale-response coverage in `npm run test:ios`

## Test Plan
- [x] `node --test ios/leaderboard-stale-response.test.mjs`
- [x] Temporary guard removal made the new test fail
- [x] `npm run test:ios`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `cd ios && xcodebuild -project FXRacing.xcodeproj -scheme FXRacing -destination 'generic/platform=iOS Simulator' -derivedDataPath /private/tmp/f10-fantasy-xcodebuild build`\n- [x] `npm run build`\n\n— gib