### PR TITLE
Cover missing-user auth sessions

### DIFF
--- a/src/auth-callbacks.test.mjs
+++ b/src/auth-callbacks.test.mjs
@@ -36,6 +36,31 @@ test("Auth.js session updates refresh username claims from the database", () => 
   assert.doesNotMatch(fullAuthSource, /session\.usernameSet/)
 })
 
+test("auth wrapper rejects sessions for missing database users", () => {
+  const [, authWrapperBody] = requireMatch(
+    fullAuthSource,
+    /export const auth = \(async \(\.\.\.args: any\[\]\) => \{([\s\S]*?)\n\}\) as typeof rawAuth/,
+    "auth wrapper",
+  )
+
+  assert.match(
+    authWrapperBody,
+    /const user = await db\.user\.findUnique\(\{\s*where: \{ id: session\.user\.id \},\s*select: \{ sessionValidAfter: true \},\s*\}\)/s,
+    "auth wrapper should look up the session user before accepting the JWT session",
+  )
+
+  const missingUserGuardMatch = authWrapperBody.match(/if \(!user\) \{\s*return null;?\s*\}/)
+  const missingUserGuardIndex = missingUserGuardMatch?.index ?? -1
+  const issuedAtIndex = authWrapperBody.indexOf("const sessionIssuedAtMs = session.user.sessionIssuedAtMs")
+
+  assert.notEqual(missingUserGuardIndex, -1, "missing database users should invalidate the session")
+  assert.notEqual(issuedAtIndex, -1, "session timestamp comparison should still exist")
+  assert.ok(
+    missingUserGuardIndex < issuedAtIndex,
+    "missing-user rejection should happen before session timestamp freshness checks",
+  )
+})
+
 test("edge auth config JWT callback only copies username claims from trusted user", () => {
   const [, jwtBody] = requireMatch(
     edgeAuthConfigSource,


### PR DESCRIPTION
Closes #260

## Summary
- add auth wrapper regression coverage for sessions whose database user row is missing
- assert missing-user rejection happens before timestamp freshness checks

## Test Plan
- [x] `node --test src/auth-callbacks.test.mjs`
- [x] Temporary removal of the missing-user guard made the new test fail
- [x] `npm run test:auth`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

— gib