### PR TITLE
Cover partial sync entries responses

### DIFF
--- a/src/app/api/cron/sync-entries/route.test.mjs
+++ b/src/app/api/cron/sync-entries/route.test.mjs
@@ -8,3 +8,27 @@ test("sync-entries only selects race statuses whose grids can still change", () 
   assert.match(route, /status:\s*\{\s*in:\s*\[\s*'UPCOMING',\s*'LIVE'\s*\]/s)
   assert.doesNotMatch(route, /status:\s*\{\s*not:\s*'COMPLETED'\s*\}/)
 })
+
+test("sync-entries skips partial provider entry sets before rewriting grids", () => {
+  assert.match(route, /const MIN_VALID_ENTRY_COUNT = 10/)
+
+  const rebuildBlock = route.match(/for \(const \{ race, drivers \} of sessionResults\) \{[\s\S]*?\n  \}/)?.[0]
+  assert.ok(rebuildBlock, "race entry rebuild loop should exist")
+
+  const tooFewIndex = rebuildBlock.indexOf("entries.length < MIN_VALID_ENTRY_COUNT")
+  const tooFewSkipIndex = rebuildBlock.indexOf("reason: `too-few-entries:${entries.length}`")
+  const existingCountIndex = rebuildBlock.indexOf("const existingCount = race._count.entries")
+  const regressionGuardIndex = rebuildBlock.indexOf("existingCount > 0 && entries.length < existingCount")
+  const regressionSkipIndex = rebuildBlock.indexOf("reason: `entry-count-regression:${existingCount}->${entries.length}`")
+  const deleteIndex = rebuildBlock.indexOf("db.raceEntry.deleteMany")
+
+  assert.notEqual(tooFewIndex, -1, "suspiciously small provider results should be guarded")
+  assert.notEqual(tooFewSkipIndex, -1, "too-few provider results should be reported as skipped")
+  assert.notEqual(existingCountIndex, -1, "existing grid size should be considered")
+  assert.notEqual(regressionGuardIndex, -1, "provider results that shrink an existing grid should be guarded")
+  assert.notEqual(regressionSkipIndex, -1, "entry count regressions should be reported as skipped")
+  assert.notEqual(deleteIndex, -1, "route should still rewrite valid grids")
+
+  assert.ok(tooFewIndex < deleteIndex, "minimum-count guard should run before deleting entries")
+  assert.ok(regressionGuardIndex < deleteIndex, "count-regression guard should run before deleting entries")
+})


### PR DESCRIPTION
Closes #262

## Summary
- add sync-entries regression coverage for partial provider response guards
- assert too-few/count-regression checks run before destructive RaceEntry rewrites

## Test Plan
- [x] `node --test src/app/api/cron/sync-entries/route.test.mjs`
- [x] Temporary removal of the partial-response guards made the new test fail
- [x] `npm run test:routes`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

— gib