### PR TITLE
Cover atomic username change guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:utils": "node --test src/lib/utils.test.mjs src/lib/observability/client-errors.test.mjs",
     "test:scoring": "node --test src/lib/scoring/formula.test.mjs",
     "test:scripts": "node --test scripts/find-cheated-picks.test.mjs scripts/tsconfig-prisma-coverage.test.mjs scripts/vercel-cli-doc.test.mjs",
-    "test:services": "node --test src/lib/services/race.service.test.mjs src/lib/services/leaderboard-rank.test.mjs src/lib/services/friendship.service.test.mjs src/lib/f1/providers/openf1.test.mjs",
+    "test:services": "node --test src/lib/services/race.service.test.mjs src/lib/services/user.service.test.mjs src/lib/services/leaderboard-rank.test.mjs src/lib/services/friendship.service.test.mjs src/lib/f1/providers/openf1.test.mjs",
     "lint": "next lint",
     "db:push": "prisma db push",
     "db:studio": "prisma studio",

--- a/src/lib/services/user.service.test.mjs
+++ b/src/lib/services/user.service.test.mjs
@@ -1,0 +1,29 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const source = await readFile(new URL("./user.service.ts", import.meta.url), "utf8")
+
+function changeUsernameSource() {
+  const start = source.indexOf("export async function changeUsername")
+  assert.notEqual(start, -1)
+
+  const end = source.indexOf("/**\n * Look up a user profile", start)
+  assert.notEqual(end, -1)
+
+  return source.slice(start, end)
+}
+
+test("changeUsername consumes the one-time username change atomically", () => {
+  const changeUsername = changeUsernameSource()
+
+  assert.match(changeUsername, /await db\.\$transaction\(async \(tx\) => \{/)
+  assert.match(
+    changeUsername,
+    /const updated = await tx\.user\.updateMany\(\{\s*where:\s*\{[\s\S]*id:\s*userId[\s\S]*usernameSet:\s*true[\s\S]*usernameChangeUsed:\s*false[\s\S]*\}[\s\S]*data:\s*\{[\s\S]*publicUsername:\s*stored[\s\S]*usernameChangeUsed:\s*true/s,
+  )
+  assert.match(
+    changeUsername,
+    /if \(updated\.count !== 1\) \{\s*throw new Error\('You have already used your one-time username change'\)/,
+  )
+})


### PR DESCRIPTION
Closes #264

## Summary
- add service-level regression coverage for the atomic one-time username change guard
- wire the new coverage into `npm run test:services`
- preserve the existing route contract and service implementation

## Test Plan
- [x] `node --test src/lib/services/user.service.test.mjs`
- [x] red check: temporarily changed the `updateMany` predicate so the new test failed, then restored it
- [x] `npm run test:services`
- [x] `npm run test:routes`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

— gib