### PR TITLE
Cover OpenF1 live classification errors

### DIFF
--- a/src/lib/f1/providers/openf1.test.mjs
+++ b/src/lib/f1/providers/openf1.test.mjs
@@ -98,3 +98,51 @@ test("getFinalResults distinguishes DNS drivers from DNF retirements", async () 
     globalThis.fetch = previousFetch
   }
 })
+
+test("getLiveClassification returns null when OpenF1 has no position rows", async () => {
+  const previousFetch = globalThis.fetch
+  globalThis.fetch = async (url) => {
+    const requestUrl = String(url)
+
+    if (requestUrl.endsWith("/position?session_key=456")) {
+      return jsonResponse([])
+    }
+
+    return new Response("not found", { status: 404, statusText: "Not Found" })
+  }
+
+  try {
+    const provider = new OpenF1Provider()
+    const classification = await provider.getLiveClassification(456)
+
+    assert.equal(classification, null)
+  } finally {
+    globalThis.fetch = previousFetch
+  }
+})
+
+test("getLiveClassification propagates OpenF1 provider failures", async () => {
+  const previousFetch = globalThis.fetch
+  globalThis.fetch = async (url) => {
+    const requestUrl = String(url)
+
+    if (requestUrl.endsWith("/position?session_key=789")) {
+      return new Response("upstream failed", {
+        status: 500,
+        statusText: "Internal Server Error",
+      })
+    }
+
+    return new Response("not found", { status: 404, statusText: "Not Found" })
+  }
+
+  try {
+    const provider = new OpenF1Provider()
+    await assert.rejects(
+      provider.getLiveClassification(789),
+      /OpenF1 HTTP 500 Internal Server Error/,
+    )
+  } finally {
+    globalThis.fetch = previousFetch
+  }
+})


### PR DESCRIPTION
Closes #269

## Summary
- add a regression test that empty OpenF1 position rows return `null` for live classification
- add a regression test that OpenF1 HTTP/provider failures reject instead of being masked as no live data

## Test Plan
- [x] `node --test src/lib/f1/providers/openf1.test.mjs`
- [x] `npm run test:services`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

— gib