### PR TITLE
Centralize RaceSummary mapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:utils": "node --test src/lib/utils.test.mjs src/lib/observability/client-errors.test.mjs",
     "test:scoring": "node --test src/lib/scoring/formula.test.mjs",
     "test:scripts": "node --test scripts/find-cheated-picks.test.mjs scripts/tsconfig-prisma-coverage.test.mjs scripts/vercel-cli-doc.test.mjs",
-    "test:services": "node --test src/lib/services/race.service.test.mjs src/lib/services/user.service.test.mjs src/lib/services/leaderboard-rank.test.mjs src/lib/services/friendship.service.test.mjs src/lib/f1/providers/openf1.test.mjs",
+    "test:services": "node --test src/lib/services/race.service.test.mjs src/lib/services/race-summary.mapper.test.mjs src/lib/services/user.service.test.mjs src/lib/services/leaderboard-rank.test.mjs src/lib/services/friendship.service.test.mjs src/lib/f1/providers/openf1.test.mjs",
     "lint": "next lint",
     "db:push": "prisma db push",
     "db:studio": "prisma studio",

--- a/src/lib/services/pick.service.ts
+++ b/src/lib/services/pick.service.ts
@@ -13,10 +13,10 @@ import { Prisma } from '@prisma/client'
 import { db } from '@/lib/db/client'
 import { isRaceLocked, isPickSetLocked } from './lock.service'
 import { z } from 'zod'
-import type { PickSetData, PickSetWithScore, RaceSummary } from '@/types/domain'
-import { RaceStatus, RaceType } from '@/types/domain'
+import type { PickSetData, PickSetWithScore } from '@/types/domain'
 import { buildSeatLookup, inferSeatKeyFromDriver } from '@/lib/f1/seats'
 import { resolveTeam } from '@/lib/f1/teams'
+import { mapRaceToSummary } from './race-summary.mapper'
 
 /**
  * Thrown when a pick cannot be created/updated because either the race-level
@@ -92,34 +92,6 @@ function mapPickSetToData(
     updatedAt: ps.updatedAt,
     lockedAt: ps.lockedAt,
     lockedSubmittedBeforeQualifying: ps.lockedSubmittedBeforeQualifying ?? null,
-  }
-}
-
-function mapRaceToSummary(race: {
-  id: string
-  seasonId: string
-  round: number
-  name: string
-  circuitName: string
-  country: string
-  type: string
-  scheduledStartUtc: Date
-  lockCutoffUtc: Date
-  status: string
-  qualifyingStartUtc?: Date | null
-}): RaceSummary {
-  return {
-    id: race.id,
-    seasonId: race.seasonId,
-    round: race.round,
-    name: race.name,
-    circuitName: race.circuitName,
-    country: race.country,
-    type: race.type as RaceType,
-    scheduledStartUtc: race.scheduledStartUtc,
-    lockCutoffUtc: race.lockCutoffUtc,
-    status: race.status as RaceStatus,
-    qualifyingStartUtc: race.qualifyingStartUtc ?? null,
   }
 }
 

--- a/src/lib/services/race-summary.mapper.test.mjs
+++ b/src/lib/services/race-summary.mapper.test.mjs
@@ -1,0 +1,42 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const source = await readFile(
+  new URL("./race-summary.mapper.ts", import.meta.url),
+  "utf8",
+)
+const raceServiceSource = await readFile(
+  new URL("./race.service.ts", import.meta.url),
+  "utf8",
+)
+const pickServiceSource = await readFile(
+  new URL("./pick.service.ts", import.meta.url),
+  "utf8",
+)
+
+test("mapRaceToSummary is the shared service-layer RaceSummary projection", () => {
+  assert.match(source, /export type RaceSummaryInput = \{/)
+  assert.match(
+    source,
+    /export function mapRaceToSummary\(race: RaceSummaryInput\): RaceSummary \{/,
+  )
+  assert.match(source, /type:\s*race\.type as RaceType/)
+  assert.match(source, /status:\s*race\.status as RaceStatus/)
+  assert.match(source, /scheduledStartUtc:\s*race\.scheduledStartUtc/)
+  assert.match(source, /lockCutoffUtc:\s*race\.lockCutoffUtc/)
+  assert.match(source, /qualifyingStartUtc:\s*race\.qualifyingStartUtc \?\? null/)
+})
+
+test("race and pick services use the shared RaceSummary mapper", () => {
+  for (const serviceSource of [raceServiceSource, pickServiceSource]) {
+    assert.match(
+      serviceSource,
+      /import \{ mapRaceToSummary \} from '\.\/race-summary\.mapper'/,
+    )
+    assert.doesNotMatch(
+      serviceSource,
+      /function mapRace(?:ToSummary)?\(race: \{/,
+    )
+  }
+})

--- a/src/lib/services/race-summary.mapper.ts
+++ b/src/lib/services/race-summary.mapper.ts
@@ -1,0 +1,32 @@
+import type { RaceSummary } from '@/types/domain'
+import { RaceStatus, RaceType } from '@/types/domain'
+
+export type RaceSummaryInput = {
+  id: string
+  seasonId: string
+  round: number
+  name: string
+  circuitName: string
+  country: string
+  type: string
+  scheduledStartUtc: Date
+  lockCutoffUtc: Date
+  status: string
+  qualifyingStartUtc?: Date | null
+}
+
+export function mapRaceToSummary(race: RaceSummaryInput): RaceSummary {
+  return {
+    id: race.id,
+    seasonId: race.seasonId,
+    round: race.round,
+    name: race.name,
+    circuitName: race.circuitName,
+    country: race.country,
+    type: race.type as RaceType,
+    scheduledStartUtc: race.scheduledStartUtc,
+    lockCutoffUtc: race.lockCutoffUtc,
+    status: race.status as RaceStatus,
+    qualifyingStartUtc: race.qualifyingStartUtc ?? null,
+  }
+}

--- a/src/lib/services/race.service.ts
+++ b/src/lib/services/race.service.ts
@@ -8,41 +8,10 @@
 
 import { db } from '@/lib/db/client'
 import type { RaceSummary, DriverSummary, RaceResultRecord } from '@/types/domain'
-import { RaceType, RaceStatus, ResultStatus } from '@/types/domain'
+import { ResultStatus } from '@/types/domain'
 import { resolveTeam, DRIVER_PHOTOS } from '@/lib/f1/teams'
 import { buildSeatLookup } from '@/lib/f1/seats'
-
-// ─────────────────────────────────────────────
-// Internal mappers
-// ─────────────────────────────────────────────
-
-function mapRace(race: {
-  id: string
-  seasonId: string
-  round: number
-  name: string
-  circuitName: string
-  country: string
-  type: string
-  scheduledStartUtc: Date
-  lockCutoffUtc: Date
-  status: string
-  qualifyingStartUtc?: Date | null
-}): RaceSummary {
-  return {
-    id: race.id,
-    seasonId: race.seasonId,
-    round: race.round,
-    name: race.name,
-    circuitName: race.circuitName,
-    country: race.country,
-    type: race.type as RaceType,
-    scheduledStartUtc: race.scheduledStartUtc,
-    lockCutoffUtc: race.lockCutoffUtc,
-    status: race.status as RaceStatus,
-    qualifyingStartUtc: race.qualifyingStartUtc ?? null,
-  }
-}
+import { mapRaceToSummary } from './race-summary.mapper'
 
 // ─────────────────────────────────────────────
 // Public API
@@ -93,7 +62,7 @@ export async function getRacesForSeason(
     },
   })
 
-  return races.map(mapRace)
+  return races.map(mapRaceToSummary)
 }
 
 /**
@@ -118,7 +87,7 @@ export async function getCurrentRace(
     orderBy: { scheduledStartUtc: 'asc' },
   })
 
-  if (live) return mapRace(live)
+  if (live) return mapRaceToSummary(live)
 
   // Next upcoming race
   const upcoming = await db.race.findFirst({
@@ -126,7 +95,7 @@ export async function getCurrentRace(
     orderBy: { scheduledStartUtc: 'asc' },
   })
 
-  if (upcoming) return mapRace(upcoming)
+  if (upcoming) return mapRaceToSummary(upcoming)
 
   // Fallback: most recently completed
   const completed = await db.race.findFirst({
@@ -134,7 +103,7 @@ export async function getCurrentRace(
     orderBy: { scheduledStartUtc: 'desc' },
   })
 
-  return completed ? mapRace(completed) : null
+  return completed ? mapRaceToSummary(completed) : null
 }
 
 /**
@@ -160,7 +129,7 @@ export async function getRaceById(
     },
   })
 
-  return race ? mapRace(race) : null
+  return race ? mapRaceToSummary(race) : null
 }
 
 /**
@@ -271,7 +240,7 @@ export async function getRaceResults(
 
   if (!race) return []
 
-  const raceSummary = mapRace(race)
+  const raceSummary = mapRaceToSummary(race)
 
   const results: RaceResultRecord[] = race.results.map((r) => ({
     driverId: r.driverId,


### PR DESCRIPTION
## Summary

- Add a shared service-layer RaceSummary mapper.
- Update race and pick services to use the shared projection.
- Add focused service coverage and include it in `npm run test:services`.

Closes #275

## Test Plan

- [x] `npm run test:services`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

Notes: build exits 0 but still emits the known missing `DATABASE_URL` Prisma messages during static generation and existing Edge runtime warnings from `jose`/`next-auth`.

— gib