### PR TITLE
Clean strict maintenance script unused vars

### DIFF
--- a/prisma/fix-grid-and-results.ts
+++ b/prisma/fix-grid-and-results.ts
@@ -183,7 +183,7 @@ async function main() {
     console.log(`\n   📊 ${race.name} (session ${sessionKey})`)
 
     // Ensure race entries exist for all 22 drivers
-    for (const [code, driverId] of Array.from(byCode.entries())) {
+    for (const driverId of Array.from(byCode.values())) {
       const exists = await db.$queryRaw<Array<{id: string}>>`
         SELECT id FROM "RaceEntry" WHERE "raceId" = ${race.id} AND "driverId" = ${driverId}
       `

--- a/scripts/restore-cancelled-races.ts
+++ b/scripts/restore-cancelled-races.ts
@@ -13,13 +13,8 @@
  */
 import { db } from '@/lib/db/client'
 
-const NAMES_TO_RESTORE = [
-  // Race id, name, type — match by all three to avoid touching anything else
-  { id: 'cmnlzx0xz002m5tcq3otjqv43', name: 'Saudi Arabian Grand Prix', type: 'MAIN' },
-] as const
-
 async function main() {
-  // Look up by name+type+round to be defensive about id drift
+  // Look up by status + name/type to be defensive about id drift.
   const targets = await db.race.findMany({
     where: {
       AND: [


### PR DESCRIPTION
## Summary

- Remove stale unused restore-script target constant.
- Iterate over grid-repair driver ids without binding an unused code value.
- Keep the restore script comment aligned with the actual lookup behavior.

Closes #276

## Test Plan

- [x] `npx tsc --noEmit --noUnusedLocals --noUnusedParameters`
- [x] `npm run test:scripts`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

Notes: build exits 0 but still emits the known missing `DATABASE_URL` Prisma messages during static generation.

— gib