### PR TITLE
Clarify static script test scope

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -56,7 +56,7 @@ jobs:
           npm run test:pages
           npm run test:utils
           npm run test:scoring
-          npm run test:scripts
+          npm run test:scripts:static
           npx tsx scripts/test-mobile-provider-email.ts
 
       - name: Build

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Useful checks:
 ```bash
 npm run test:services
 npm run test:routes
-npm run test:scripts
+npm run test:scripts:static
 npx tsc --noEmit
 npm run lint
 npm run build
@@ -46,6 +46,8 @@ See [AGENTS.md](AGENTS.md) and
 [ai/docs/architecture.md](ai/docs/architecture.md) before making non-trivial
 changes. The architecture doc is the codebase map and the shared source of
 truth for service boundaries, API routes, data flow, and verification order.
+`npm run test:scripts:static` covers static script guards only; DB-backed
+operational scripts still require their documented manual dry-run/apply flow.
 
 ## Operations
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:pages": "node --test 'src/app/(main)/races/race-detail-page.test.mjs' 'src/app/(auth)/onboarding/username/page.test.mjs' 'src/app/(main)/leaderboard/search-params.test.mjs'",
     "test:utils": "node --test src/lib/utils.test.mjs src/lib/observability/client-errors.test.mjs",
     "test:scoring": "node --test src/lib/scoring/formula.test.mjs",
-    "test:scripts": "node --test scripts/find-cheated-picks.test.mjs scripts/tsconfig-prisma-coverage.test.mjs scripts/vercel-cli-doc.test.mjs",
+    "test:scripts:static": "node --test scripts/find-cheated-picks.test.mjs scripts/tsconfig-prisma-coverage.test.mjs scripts/vercel-cli-doc.test.mjs",
     "test:services": "node --test src/lib/services/race.service.test.mjs src/lib/services/race-summary.mapper.test.mjs src/lib/services/user.service.test.mjs src/lib/services/leaderboard-rank.test.mjs src/lib/services/friendship.service.test.mjs src/lib/f1/providers/openf1.test.mjs",
     "lint": "next lint",
     "db:push": "prisma db push",


### PR DESCRIPTION
## Summary

- Rename `test:scripts` to `test:scripts:static` so the scope is explicit.
- Update CI and README references to the renamed static script suite.
- Document that DB-backed operational scripts still use their manual dry-run/apply flows.

Closes #277

## Test Plan

- [x] `npm run test:scripts:static`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

Notes: build exits 0 but still emits the known missing `DATABASE_URL` Prisma messages during static generation.

— gib