### PR TITLE
Avoid build-time Prisma page queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:components": "node --test src/components/ui/segmented-control.test.mjs 'src/app/(main)/profile/profile-async-guards.test.mjs' 'src/app/(main)/UserAvatarMenu.test.mjs' src/components/picks/PickHero.test.mjs src/components/picks/PicksDisplay.test.mjs src/components/legal/LegalModal.test.mjs src/components/session-sync.test.mjs src/components/race/lock-countdown-timer.test.mjs src/components/race/HeroVisualization.test.mjs src/components/race/RaceResultsCard.test.mjs",
     "test:ios": "node --test ios/project-signing.test.mjs ios/signin-view-model.test.mjs ios/diagnostics-entry.test.mjs ios/profile-refresh-key.test.mjs ios/races-list-ordering.test.mjs ios/race-detail-load-reset.test.mjs ios/leaderboard-guest-access.test.mjs ios/leaderboard-stale-response.test.mjs",
     "test:ios-config": "node --test ios/project-signing.test.mjs",
-    "test:pages": "node --test 'src/app/(main)/races/race-detail-page.test.mjs' 'src/app/(auth)/onboarding/username/page.test.mjs' 'src/app/(main)/leaderboard/search-params.test.mjs'",
+    "test:pages": "node --test 'src/app/(main)/dynamic-pages.test.mjs' 'src/app/(main)/races/race-detail-page.test.mjs' 'src/app/(auth)/onboarding/username/page.test.mjs' 'src/app/(main)/leaderboard/search-params.test.mjs'",
     "test:utils": "node --test src/lib/utils.test.mjs src/lib/observability/client-errors.test.mjs",
     "test:scoring": "node --test src/lib/scoring/formula.test.mjs",
     "test:scripts:static": "node --test scripts/find-cheated-picks.test.mjs scripts/tsconfig-prisma-coverage.test.mjs scripts/vercel-cli-doc.test.mjs",

--- a/src/app/(main)/dynamic-pages.test.mjs
+++ b/src/app/(main)/dynamic-pages.test.mjs
@@ -1,0 +1,19 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const pages = [
+  ["races page", new URL("./races/page.tsx", import.meta.url)],
+  ["leaderboard page", new URL("./leaderboard/page.tsx", import.meta.url)],
+]
+
+test("DB-backed main pages opt out of build-time prerendering", async () => {
+  for (const [name, url] of pages) {
+    const source = await readFile(url, "utf8")
+    assert.match(
+      source,
+      /export const dynamic = ["']force-dynamic["']/,
+      `${name} should not query Prisma during static generation`,
+    )
+  }
+})

--- a/src/app/(main)/leaderboard/page.tsx
+++ b/src/app/(main)/leaderboard/page.tsx
@@ -12,6 +12,8 @@ import {
   normalizeLeaderboardSort,
 } from "./search-params"
 
+export const dynamic = "force-dynamic"
+
 type LeaderboardSearchParamValue = string | string[] | undefined
 
 interface LeaderboardSearchParams {

--- a/src/app/(main)/races/page.tsx
+++ b/src/app/(main)/races/page.tsx
@@ -6,6 +6,8 @@ import { OnboardingCarousel } from "@/components/onboarding/OnboardingCarousel"
 import { RacesListClient } from "./RacesListClient"
 import type { SerializedRaceSummary } from "@/types/domain"
 
+export const dynamic = "force-dynamic"
+
 export default async function RacesPage() {
   // Run auth + season fetch in parallel — they're independent.
   const [session, season] = await Promise.all([auth(), getActiveSeason()])


### PR DESCRIPTION
## Summary
- Mark the DB-backed races and leaderboard pages as dynamic so Next.js does not prerender them during builds without a database.
- Add a page-level regression test that keeps both routes opted out of static prerendering.
- Wire that regression into `npm run test:pages`.

Closes #272

## Test Plan
- [x] `npm run test:pages`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build` confirms `/races` and `/leaderboard` are dynamic and emits no Prisma `DATABASE_URL` warnings.

— gib
