### PR TITLE
Guard 2026 maintenance scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:pages": "node --test 'src/app/(main)/dynamic-pages.test.mjs' 'src/app/(main)/races/race-detail-page.test.mjs' 'src/app/(auth)/onboarding/username/page.test.mjs' 'src/app/(main)/leaderboard/search-params.test.mjs'",
     "test:utils": "node --test src/lib/utils.test.mjs src/lib/observability/client-errors.test.mjs",
     "test:scoring": "node --test src/lib/scoring/formula.test.mjs",
-    "test:scripts:static": "node --test scripts/db-entrypoint.test.mjs scripts/find-cheated-picks.test.mjs scripts/tsconfig-prisma-coverage.test.mjs scripts/vercel-cli-doc.test.mjs",
+    "test:scripts:static": "node --test scripts/db-entrypoint.test.mjs scripts/find-cheated-picks.test.mjs scripts/maintenance-season-guards.test.mjs scripts/tsconfig-prisma-coverage.test.mjs scripts/vercel-cli-doc.test.mjs",
     "test:services": "node --test src/lib/services/race.service.test.mjs src/lib/services/race-summary.mapper.test.mjs src/lib/services/user.service.test.mjs src/lib/services/leaderboard-rank.test.mjs src/lib/services/friendship.service.test.mjs src/lib/f1/providers/openf1.test.mjs",
     "lint": "next lint",
     "db:push": "prisma db push",

--- a/scripts/maintenance-season-guards.test.mjs
+++ b/scripts/maintenance-season-guards.test.mjs
@@ -1,0 +1,46 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const reconcileSource = await readFile(
+  new URL("./reconcile-2026-calendar.ts", import.meta.url),
+  "utf8",
+)
+const renumberSource = await readFile(
+  new URL("./renumber-2026-rounds.ts", import.meta.url),
+  "utf8",
+)
+const restoreSource = await readFile(
+  new URL("./restore-cancelled-races.ts", import.meta.url),
+  "utf8",
+)
+
+function assertRequiresActive2026Season(source, scriptName) {
+  assert.match(
+    source,
+    /const season = await getActiveSeason\(\)[\s\S]*if \(season\.year !== 2026\)[\s\S]*process\.exit\(1\)/,
+    `${scriptName} should abort before planning writes unless the active season is 2026`,
+  )
+}
+
+test("2026 calendar reconciliation refuses non-2026 active seasons", () => {
+  assertRequiresActive2026Season(
+    reconcileSource,
+    "scripts/reconcile-2026-calendar.ts",
+  )
+})
+
+test("2026 round renumbering refuses non-2026 active seasons", () => {
+  assertRequiresActive2026Season(
+    renumberSource,
+    "scripts/renumber-2026-rounds.ts",
+  )
+})
+
+test("cancelled race restore is constrained to the 2026 season", () => {
+  assert.match(
+    restoreSource,
+    /season:\s*\{\s*year:\s*2026\s*\}/,
+    "scripts/restore-cancelled-races.ts should not restore matching race names outside 2026",
+  )
+})

--- a/scripts/reconcile-2026-calendar.ts
+++ b/scripts/reconcile-2026-calendar.ts
@@ -143,6 +143,12 @@ async function main() {
     console.error('No active season found. Aborting.')
     process.exit(1)
   }
+  if (season.year !== 2026) {
+    console.error(
+      `Active season is ${season.year}; this 2026 calendar reconciliation script must not run for another season.`,
+    )
+    process.exit(1)
+  }
   console.log(`Active season: id=${season.id} year=${season.year}`)
 
   const meetings = await fetchOpenF1<OpenF1Meeting>(

--- a/scripts/renumber-2026-rounds.ts
+++ b/scripts/renumber-2026-rounds.ts
@@ -111,6 +111,12 @@ async function main() {
     console.error('No active season found. Aborting.')
     process.exit(1)
   }
+  if (season.year !== 2026) {
+    console.error(
+      `Active season is ${season.year}; this 2026 round renumbering script must not run for another season.`,
+    )
+    process.exit(1)
+  }
   console.log(`Active season: id=${season.id} year=${season.year}`)
 
   const rows = (await db.race.findMany({

--- a/scripts/restore-cancelled-races.ts
+++ b/scripts/restore-cancelled-races.ts
@@ -19,6 +19,7 @@ async function main() {
     where: {
       AND: [
         { status: 'LIVE' },
+        { season: { year: 2026 } },
         {
           OR: [
             { name: 'Saudi Arabian Grand Prix', type: 'MAIN' },


### PR DESCRIPTION
## Summary
- abort the 2026 reconciliation and renumbering scripts when the active season is not 2026
- constrain the cancelled-race restore script to 2026 rows
- add static regression coverage for these one-off maintenance guards

Closes #295

## Test Plan
- [x] RED before fix: `node --test scripts/maintenance-season-guards.test.mjs` failed 3/3 for missing guards/filter
- [x] `node --test scripts/maintenance-season-guards.test.mjs`
- [x] `npm run test:scripts:static`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `git diff --check`
- [x] `npm run build`

## Review
- [x] Subagent review completed with no findings

— gib