### PR TITLE
Make domain error regex matching stateless

### DIFF
--- a/src/lib/api/errors.js
+++ b/src/lib/api/errors.js
@@ -31,8 +31,9 @@ function matchesDomainError(rule, error, message) {
     return true
   }
 
-  if (rule.pattern instanceof RegExp && rule.pattern.test(message)) {
-    return true
+  if (rule.pattern instanceof RegExp) {
+    rule.pattern.lastIndex = 0
+    return rule.pattern.test(message)
   }
 
   return false

--- a/src/lib/api/errors.test.mjs
+++ b/src/lib/api/errors.test.mjs
@@ -13,6 +13,24 @@ test("sanitizedErrorResponse preserves allowlisted domain errors", async () => {
   assert.deepEqual(await response.json(), { error: "Race is locked" })
 })
 
+test("sanitizedErrorResponse treats reused global regex rules as stateless", async () => {
+  const domainErrors = [{ pattern: /locked/g, status: 423 }]
+
+  const firstResponse = sanitizedErrorResponse(new Error("Race is locked"), {
+    domainErrors,
+    fallbackMessage: "Failed to save pick",
+    logger: null,
+  })
+  const secondResponse = sanitizedErrorResponse(new Error("Race is locked"), {
+    domainErrors,
+    fallbackMessage: "Failed to save pick",
+    logger: null,
+  })
+
+  assert.equal(firstResponse.status, 423)
+  assert.equal(secondResponse.status, 423)
+})
+
 test("sanitizedErrorResponse logs unexpected errors and returns a generic body", async () => {
   const logs = []
   const response = sanitizedErrorResponse(


### PR DESCRIPTION
## Summary
- reset regex `lastIndex` before testing domain-error patterns
- add coverage for reusing a global regex rule across multiple sanitized responses

Closes #294

## Test Plan
- [x] RED before fix: `node --test src/lib/api/errors.test.mjs` failed with second response `500 !== 423`
- [x] `node --test src/lib/api/errors.test.mjs`
- [x] `npm run test:routes`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `git diff --check`
- [x] `npm run build`

## Review
- [x] Subagent review completed with no findings

— gib