### PR TITLE
Cover privacy page copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:components": "node --test src/components/ui/segmented-control.test.mjs 'src/app/(main)/profile/profile-async-guards.test.mjs' 'src/app/(main)/UserAvatarMenu.test.mjs' src/components/picks/PickHero.test.mjs src/components/picks/PicksDisplay.test.mjs src/components/legal/LegalModal.test.mjs src/components/session-sync.test.mjs src/components/race/lock-countdown-timer.test.mjs src/components/race/HeroVisualization.test.mjs src/components/race/RaceResultsCard.test.mjs",
     "test:ios": "node --test ios/project-signing.test.mjs ios/signin-view-model.test.mjs ios/diagnostics-entry.test.mjs ios/profile-refresh-key.test.mjs ios/races-list-ordering.test.mjs ios/race-detail-load-reset.test.mjs ios/leaderboard-guest-access.test.mjs ios/leaderboard-stale-response.test.mjs",
     "test:ios-config": "node --test ios/project-signing.test.mjs",
-    "test:pages": "node --test 'src/app/(main)/dynamic-pages.test.mjs' 'src/app/(main)/races/race-detail-page.test.mjs' 'src/app/(auth)/onboarding/username/page.test.mjs' 'src/app/(main)/leaderboard/search-params.test.mjs'",
+    "test:pages": "node --test 'src/app/(main)/dynamic-pages.test.mjs' 'src/app/(main)/races/race-detail-page.test.mjs' 'src/app/(auth)/onboarding/username/page.test.mjs' 'src/app/(main)/leaderboard/search-params.test.mjs' src/app/privacy/page.test.mjs",
     "test:utils": "node --test src/lib/utils.test.mjs src/lib/observability/client-errors.test.mjs",
     "test:scoring": "node --test src/lib/scoring/formula.test.mjs",
     "test:scripts:static": "node --test scripts/db-entrypoint.test.mjs scripts/find-cheated-picks.test.mjs scripts/maintenance-season-guards.test.mjs scripts/tsconfig-prisma-coverage.test.mjs scripts/vercel-cli-doc.test.mjs",

--- a/src/app/privacy/page.test.mjs
+++ b/src/app/privacy/page.test.mjs
@@ -1,0 +1,12 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const page = await readFile(new URL("./page.tsx", import.meta.url), "utf8")
+
+test("privacy page keeps required support and unaffiliated notices", () => {
+  assert.match(page, /title:\s*['"]Privacy Policy .* FX Racing['"]/)
+  assert.match(page, /href=["']mailto:support@fxracing\.ca["']/)
+  assert.match(page, /not affiliated with/)
+  assert.match(page, /Formula 1/)
+})


### PR DESCRIPTION
## Summary
- add a static privacy page regression for title/support/legal notice copy
- wire the privacy test into `test:pages`

Closes #297

## Test Plan
- [x] `node --test src/app/privacy/page.test.mjs`
- [x] `npm run test:pages`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `git diff --check`
- [x] `npm run build`

## Review
- [x] Subagent review completed with no findings

— gib