### PR TITLE
Hide cancelled races from public list

### DIFF
--- a/src/lib/services/race.service.test.mjs
+++ b/src/lib/services/race.service.test.mjs
@@ -6,6 +6,9 @@ const source = await readFile(new URL("./race.service.ts", import.meta.url), "ut
 const getRaceByIdBody = source.match(
   /export async function getRaceById[\s\S]*?const race = await db\.race\.findUnique\(\{([\s\S]*?)\n  \}\)/,
 )?.[1]
+const getRacesForSeasonBody = source.match(
+  /export async function getRacesForSeason[\s\S]*?const races = await db\.race\.findMany\(\{([\s\S]*?)\n  \}\)/,
+)?.[1]
 const getRaceEntrantsStart = source.indexOf("export async function getRaceEntrants")
 const getRaceResultsStart = source.indexOf("export async function getRaceResults")
 const getRaceEntrantsBody =
@@ -14,7 +17,12 @@ const getRaceEntrantsBody =
     : null
 
 assert.ok(getRaceByIdBody, "expected to find getRaceById findUnique query")
+assert.ok(getRacesForSeasonBody, "expected to find getRacesForSeason findMany query")
 assert.ok(getRaceEntrantsBody, "expected to find getRaceEntrants body")
+
+test("getRacesForSeason excludes cancelled rows from public race lists", () => {
+  assert.match(getRacesForSeasonBody, /where:\s*\{\s*seasonId,\s*status:\s*\{\s*not:\s*['"]CANCELLED['"]\s*\}/)
+})
 
 test("getRaceById selects qualifyingStartUtc for race detail serialization", () => {
   assert.match(getRaceByIdBody, /qualifyingStartUtc:\s*true/)

--- a/src/lib/services/race.service.ts
+++ b/src/lib/services/race.service.ts
@@ -45,7 +45,7 @@ export async function getRacesForSeason(
   seasonId: string,
 ): Promise<RaceSummary[]> {
   const races = await db.race.findMany({
-    where: { seasonId },
+    where: { seasonId, status: { not: 'CANCELLED' } },
     orderBy: { scheduledStartUtc: 'asc' },
     select: {
       id: true,


### PR DESCRIPTION
Closes #299

## Summary
- Filter `CANCELLED` races out of `getRacesForSeason`, which backs the public `/api/races` list.
- Keep direct race detail lookups readable for cancelled race IDs to avoid expanding this cleanup beyond the list surface.
- Add a source regression that locks the public list query filter in place.

## Test Plan
- [x] `npm run test:services`
- [x] `npm run test:routes`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `git diff --check`
- [x] Focused subagent review: spec ✅, quality approved

— gib