### PR TITLE
Reject picks for cancelled races

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:utils": "node --test src/lib/utils.test.mjs src/lib/observability/client-errors.test.mjs",
     "test:scoring": "node --test src/lib/scoring/formula.test.mjs",
     "test:scripts:static": "node --test scripts/db-entrypoint.test.mjs scripts/find-cheated-picks.test.mjs scripts/install-pickset-triggers.test.mjs scripts/maintenance-season-guards.test.mjs scripts/tsconfig-prisma-coverage.test.mjs scripts/vercel-cli-doc.test.mjs",
-    "test:services": "node --test src/lib/services/race.service.test.mjs src/lib/services/race-summary.mapper.test.mjs src/lib/services/user.service.test.mjs src/lib/services/leaderboard-rank.test.mjs src/lib/services/friendship.service.test.mjs src/lib/f1/providers/openf1.test.mjs",
+    "test:services": "node --test src/lib/services/pick.service.test.mjs src/lib/services/race.service.test.mjs src/lib/services/race-summary.mapper.test.mjs src/lib/services/user.service.test.mjs src/lib/services/leaderboard-rank.test.mjs src/lib/services/friendship.service.test.mjs src/lib/f1/providers/openf1.test.mjs",
     "lint": "next lint",
     "db:push": "prisma db push",
     "db:studio": "prisma studio",

--- a/src/app/api/picks/post-handler.js
+++ b/src/app/api/picks/post-handler.js
@@ -4,6 +4,7 @@ import { sanitizedErrorResponse } from "../../../lib/api/errors.js"
 const PICK_SAVE_DOMAIN_ERRORS = [
   { pattern: /locked/i, status: 423 },
   { pattern: /^Race not found:/, status: 404 },
+  { pattern: /^Race .+ is cancelled/, status: 409 },
   { pattern: /^The following driver IDs are not registered entrants for this race:/, status: 400 },
   { pattern: /^A pick set already exists for this race/, status: 409 },
 ]

--- a/src/app/api/picks/post-handler.test.mjs
+++ b/src/app/api/picks/post-handler.test.mjs
@@ -78,6 +78,19 @@ test("POST preserves locked race domain errors", async () => {
   assert.deepEqual(await responseJson(response), { error: "Race is locked" })
 })
 
+test("POST preserves cancelled race domain errors", async () => {
+  const response = await handlePickPost(pickRequest({ raceId: "race-1" }), dependencies({
+    createOrUpdatePick: async () => {
+      throw new Error("Race race-1 is cancelled — picks can no longer be submitted")
+    },
+  }))
+
+  assert.equal(response.status, 409)
+  assert.deepEqual(await responseJson(response), {
+    error: "Race race-1 is cancelled — picks can no longer be submitted",
+  })
+})
+
 test("POST preserves pick validation domain errors", async () => {
   const response = await handlePickPost(pickRequest({ raceId: "race-1" }), dependencies({
     createOrUpdatePick: async () => {

--- a/src/lib/services/pick.service.test.mjs
+++ b/src/lib/services/pick.service.test.mjs
@@ -1,0 +1,52 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const source = await readFile(new URL("./pick.service.ts", import.meta.url), "utf8")
+const createOrUpdatePickStart = source.indexOf("export async function createOrUpdatePick")
+const getPickForRaceStart = source.indexOf("export async function getPickForRace")
+const createOrUpdatePickBody =
+  createOrUpdatePickStart >= 0 && getPickForRaceStart > createOrUpdatePickStart
+    ? source.slice(createOrUpdatePickStart, getPickForRaceStart)
+    : null
+
+assert.ok(createOrUpdatePickBody, "expected to find createOrUpdatePick body")
+
+test("createOrUpdatePick rejects cancelled races before validating entrants or writing", () => {
+  const raceStatusGuard = createOrUpdatePickBody.indexOf("race.status === 'CANCELLED'")
+  const entrantsLookup = createOrUpdatePickBody.indexOf("tx.raceEntry.findMany")
+  const updateWrite = createOrUpdatePickBody.indexOf("tx.pickSet.updateMany")
+  const createWrite = createOrUpdatePickBody.indexOf("tx.pickSet.create")
+
+  assert.match(createOrUpdatePickBody, /const race = await lockRaceForPickWrite\(tx, validated\.raceId\)/)
+  assert.notEqual(raceStatusGuard, -1)
+  assert.ok(raceStatusGuard < entrantsLookup)
+  assert.ok(raceStatusGuard < updateWrite)
+  assert.ok(raceStatusGuard < createWrite)
+  assert.match(
+    source,
+    /function cancelledRacePickMessage\(raceId: string\): string \{\s*return `Race \$\{raceId\} is cancelled/,
+  )
+  assert.match(
+    createOrUpdatePickBody,
+    /throw new Error\(cancelledRacePickMessage\(validated\.raceId\)\)/,
+  )
+})
+
+test("createOrUpdatePick reasserts cancelled race guards for update and create writes", () => {
+  assert.match(
+    source,
+    /async function lockRaceForPickWrite[\s\S]*?\$queryRaw[\s\S]*?SELECT[\s\S]*?FROM "Race"[\s\S]*?WHERE "id" = \$\{raceId\}[\s\S]*?FOR UPDATE/,
+  )
+  assert.match(
+    createOrUpdatePickBody,
+    /race:\s*\{[\s\S]*?lockCutoffUtc:\s*\{\s*gt:\s*new Date\(\)\s*\}[\s\S]*?status:\s*\{\s*not:\s*['"]CANCELLED['"]/,
+  )
+
+  assert.doesNotMatch(
+    createOrUpdatePickBody,
+    /const fresh = await tx\.race\.findUnique/,
+  )
+  assert.doesNotMatch(createOrUpdatePickBody, /createPickSetIfRaceWritable/)
+  assert.match(createOrUpdatePickBody, /if \(race\.status === ['"]CANCELLED['"]\)[\s\S]*?tx\.pickSet\.create/)
+})

--- a/src/lib/services/pick.service.ts
+++ b/src/lib/services/pick.service.ts
@@ -2,7 +2,7 @@
  * Pick creation and retrieval service.
  *
  * Enforces:
- *   - Race must exist and not be locked before creating/updating picks
+ *   - Race must exist, not be cancelled, and not be locked before creating/updating picks
  *   - All three picked drivers must be different
  *   - All three picked drivers must be registered race entrants
  *   - Existing pick sets that have been explicitly locked cannot be mutated
@@ -30,6 +30,10 @@ export class PickLockedError extends Error {
     super(message)
     this.name = 'PickLockedError'
   }
+}
+
+function cancelledRacePickMessage(raceId: string): string {
+  return `Race ${raceId} is cancelled — picks can no longer be submitted`
 }
 
 // ─────────────────────────────────────────────
@@ -136,6 +140,33 @@ function resolveStoredSeatKey(
   return inferSeatKeyFromDriver(toSeatAwareDriver(driver))
 }
 
+async function lockRaceForPickWrite(
+  tx: Prisma.TransactionClient,
+  raceId: string,
+): Promise<{
+  id: string
+  lockCutoffUtc: Date
+  status: string
+} | null> {
+  const rows = await tx.$queryRaw<
+    {
+      id: string
+      lockCutoffUtc: Date
+      status: string
+    }[]
+  >(Prisma.sql`
+    SELECT
+      "id",
+      "lockCutoffUtc",
+      "status"
+    FROM "Race"
+    WHERE "id" = ${raceId}
+    FOR UPDATE
+  `)
+
+  return rows[0] ?? null
+}
+
 // ─────────────────────────────────────────────
 // Service functions
 // ─────────────────────────────────────────────
@@ -146,7 +177,7 @@ function resolveStoredSeatKey(
  * Guard order:
  *   1. Validate input shape with Zod (throws ZodError on failure)
  *   2. Race must exist
- *   3. Race must not be locked (lockCutoffUtc)
+ *   3. Race must not be cancelled or locked (lockCutoffUtc)
  *   4. All three drivers must be registered as race entrants
  *   5. Existing pick set must not have lockedAt set
  */
@@ -158,17 +189,19 @@ export async function createOrUpdatePick(
   const validated = CreatePickSchema.parse(input)
 
   return db.$transaction(async (tx) => {
-    // 2. Load race
-    const race = await tx.race.findUnique({
-      where: { id: validated.raceId },
-      select: { id: true, lockCutoffUtc: true, status: true },
-    })
+    // 2. Load and lock race. This serializes race status changes with both
+    // pick create and update writes for the duration of this transaction.
+    const race = await lockRaceForPickWrite(tx, validated.raceId)
 
     if (!race) {
       throw new Error(`Race not found: ${validated.raceId}`)
     }
 
-    // 3. Race-level lock check (best-effort — DB guard below is authoritative)
+    // 3. Race-level availability checks (best-effort — DB guard below is authoritative)
+    if (race.status === 'CANCELLED') {
+      throw new Error(cancelledRacePickMessage(validated.raceId))
+    }
+
     if (isRaceLocked(race)) {
       throw new PickLockedError(
         `Race ${validated.raceId} is locked — picks can no longer be submitted`,
@@ -213,14 +246,17 @@ export async function createOrUpdatePick(
 
     // 5. Atomic guarded update — re-asserts both invariants at the DB level.
     // Two concurrent submits at lockCutoff − Δ both pass the JS check above,
-    // but only the request whose write commits while lockCutoffUtc > now()
-    // and lockedAt IS NULL succeeds.
+    // but only the request whose write commits while lockCutoffUtc > now(),
+    // status is not CANCELLED, and lockedAt IS NULL succeeds.
     const updated = await tx.pickSet.updateMany({
       where: {
         userId,
         raceId: validated.raceId,
         lockedAt: null,
-        race: { lockCutoffUtc: { gt: new Date() } },
+        race: {
+          lockCutoffUtc: { gt: new Date() },
+          status: { not: 'CANCELLED' },
+        },
       },
       data,
     })
@@ -238,19 +274,33 @@ export async function createOrUpdatePick(
             'This pick set has been locked and can no longer be edited',
           )
         }
-        // Row exists but the relation guard didn't match — race must be locked.
+
+        const currentRace = await tx.race.findUnique({
+          where: { id: validated.raceId },
+          select: { lockCutoffUtc: true, status: true },
+        })
+        if (!currentRace) {
+          throw new Error(`Race not found: ${validated.raceId}`)
+        }
+        if (currentRace.status === 'CANCELLED') {
+          throw new Error(cancelledRacePickMessage(validated.raceId))
+        }
+        if (isRaceLocked(currentRace)) {
+          throw new PickLockedError(
+            `Race ${validated.raceId} is locked — picks can no longer be submitted`,
+          )
+        }
+
+        // Row exists but the relation guard did not match.
         throw new PickLockedError(
           `Race ${validated.raceId} is locked — picks can no longer be submitted`,
         )
       }
 
-      // No existing row — create one. Re-check race lock first inside the tx
-      // so we don't insert a fresh pick after the cutoff.
-      const fresh = await tx.race.findUnique({
-        where: { id: validated.raceId },
-        select: { lockCutoffUtc: true },
-      })
-      if (!fresh || isRaceLocked(fresh)) {
+      if (race.status === 'CANCELLED') {
+        throw new Error(cancelledRacePickMessage(validated.raceId))
+      }
+      if (isRaceLocked(race)) {
         throw new PickLockedError(
           `Race ${validated.raceId} is locked — picks can no longer be submitted`,
         )


### PR DESCRIPTION
Closes #304

## Summary
- Reject pick submissions for `CANCELLED` races before entrant validation.
- Serialize pick writes with race status changes by locking the `Race` row with `FOR UPDATE` inside `createOrUpdatePick`.
- Reassert `status != CANCELLED` on existing-row updates and map cancelled-race domain errors intentionally in `/api/picks`.
- Add service and route regressions for cancelled create/update/write-path behavior and route mapping.

## Test Plan
- [x] Red cycle: service and route regressions failed before implementation
- [x] `node --test src/lib/services/pick.service.test.mjs`
- [x] `node --test src/app/api/picks/post-handler.test.mjs`
- [x] `npm run test:services`
- [x] `npm run test:routes`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `git diff --check`
- [x] Focused subagent re-review: spec ✅, quality approved

— gib