### PR TITLE
Defer empty OpenF1 stint results

### DIFF
--- a/src/lib/f1/providers/openf1.test.mjs
+++ b/src/lib/f1/providers/openf1.test.mjs
@@ -99,6 +99,45 @@ test("getFinalResults distinguishes DNS drivers from DNF retirements", async () 
   }
 })
 
+test("getFinalResults defers final classification when stints are empty", async () => {
+  const previousFetch = globalThis.fetch
+  globalThis.fetch = async (url) => {
+    const requestUrl = String(url)
+
+    if (requestUrl.endsWith("/position?session_key=234")) {
+      return jsonResponse([
+        {
+          session_key: 234,
+          driver_number: 1,
+          position: 1,
+          date: "2026-06-21T15:00:00.000Z",
+        },
+        {
+          session_key: 234,
+          driver_number: 2,
+          position: 2,
+          date: "2026-06-21T15:00:00.000Z",
+        },
+      ])
+    }
+
+    if (requestUrl.endsWith("/stints?session_key=234")) {
+      return jsonResponse([])
+    }
+
+    return new Response("not found", { status: 404, statusText: "Not Found" })
+  }
+
+  try {
+    const provider = new OpenF1Provider()
+    const results = await provider.getFinalResults(234)
+
+    assert.deepEqual(results, [])
+  } finally {
+    globalThis.fetch = previousFetch
+  }
+})
+
 test("getLiveClassification returns null when OpenF1 has no position rows", async () => {
   const previousFetch = globalThis.fetch
   globalThis.fetch = async (url) => {

--- a/src/lib/f1/providers/openf1.ts
+++ b/src/lib/f1/providers/openf1.ts
@@ -260,6 +260,13 @@ export class OpenF1Provider implements F1ProviderAdapter {
     try {
       const stintRaw = await openF1Fetch<OpenF1Stint>(`/stints?session_key=${sessionKey}`)
 
+      // A successful empty stints response means OpenF1 has not published the
+      // settled race-lap evidence yet. Positions alone are not enough to infer
+      // final classifications, so let callers defer ingestion.
+      if (stintRaw.length === 0 && latestByDriver.size > 0) {
+        return []
+      }
+
       const lastLap = new Map<number, number>()
       for (const stint of stintRaw) {
         const cur = lastLap.get(stint.driver_number) ?? 0


### PR DESCRIPTION
Closes #296

## Summary
- Treat a successful empty OpenF1 `/stints` response as not-ready final result evidence when `/position` has drivers.
- Return `[]` so result ingestion defers instead of writing inferred `CLASSIFIED` rows from positions alone.
- Add a provider regression for position rows plus empty stints.

## Test Plan
- [x] Red cycle: provider regression failed before implementation
- [x] `node --test src/lib/f1/providers/openf1.test.mjs`
- [x] `npm run test:services`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `git diff --check`
- [x] Focused subagent review: spec ✅, quality approved

— gib