### PR TITLE
Backfill partial locked snapshots

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:pages": "node --test 'src/app/(main)/dynamic-pages.test.mjs' 'src/app/(main)/races/race-detail-page.test.mjs' 'src/app/(auth)/onboarding/username/page.test.mjs' 'src/app/(main)/leaderboard/search-params.test.mjs' src/app/privacy/page.test.mjs",
     "test:utils": "node --test src/lib/utils.test.mjs src/lib/observability/client-errors.test.mjs",
     "test:scoring": "node --test src/lib/scoring/formula.test.mjs",
-    "test:scripts:static": "node --test scripts/db-entrypoint.test.mjs scripts/find-cheated-picks.test.mjs scripts/install-pickset-triggers.test.mjs scripts/maintenance-season-guards.test.mjs scripts/tsconfig-prisma-coverage.test.mjs scripts/vercel-cli-doc.test.mjs",
+    "test:scripts:static": "node --test scripts/backfill-locked-snapshots.test.mjs scripts/db-entrypoint.test.mjs scripts/find-cheated-picks.test.mjs scripts/install-pickset-triggers.test.mjs scripts/maintenance-season-guards.test.mjs scripts/tsconfig-prisma-coverage.test.mjs scripts/vercel-cli-doc.test.mjs",
     "test:services": "node --test src/lib/services/pick.service.test.mjs src/lib/services/race.service.test.mjs src/lib/services/race-summary.mapper.test.mjs src/lib/services/user.service.test.mjs src/lib/services/leaderboard-rank.test.mjs src/lib/services/friendship.service.test.mjs src/lib/f1/providers/openf1.test.mjs",
     "lint": "next lint",
     "db:push": "prisma db push",

--- a/scripts/backfill-locked-snapshots.test.mjs
+++ b/scripts/backfill-locked-snapshots.test.mjs
@@ -1,0 +1,31 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const source = await readFile(new URL("./backfill-locked-snapshots.ts", import.meta.url), "utf8")
+const targetQuery = source.match(
+  /const before = await db\.\$queryRaw<Array<\{ count: bigint \}>>`([\s\S]*?)`/,
+)?.[1]
+const updateQuery = source.match(
+  /const updated = await db\.\$executeRaw`([\s\S]*?)`/,
+)?.[1]
+
+assert.ok(targetQuery, "expected to find the target count query")
+assert.ok(updateQuery, "expected to find the snapshot update query")
+
+test("backfill targets any locked row missing a driver snapshot", () => {
+  for (const query of [targetQuery, updateQuery]) {
+    assert.match(query, /"lockedAt" IS NOT NULL/)
+
+    for (const field of [
+      "lockedTenthPlaceDriverId",
+      "lockedWinnerDriverId",
+      "lockedDnfDriverId",
+    ]) {
+      assert.match(query, new RegExp(`"${field}" IS NULL`))
+    }
+
+    assert.match(query, /OR\s+"lockedWinnerDriverId" IS NULL/)
+    assert.match(query, /OR\s+"lockedDnfDriverId" IS NULL/)
+  }
+})

--- a/scripts/backfill-locked-snapshots.ts
+++ b/scripts/backfill-locked-snapshots.ts
@@ -8,7 +8,7 @@
  *
  *   npx tsx scripts/backfill-locked-snapshots.ts
  *
- * Idempotent: WHERE clause skips rows whose snapshot is already populated.
+ * Idempotent: WHERE clause skips rows whose driver snapshot is already populated.
  */
 import { db } from '@/lib/db/client'
 
@@ -17,10 +17,12 @@ async function main() {
     SELECT COUNT(*)::bigint AS count
     FROM "PickSet"
     WHERE "lockedAt" IS NOT NULL
-      AND "lockedTenthPlaceDriverId" IS NULL
+      AND ("lockedTenthPlaceDriverId" IS NULL
+        OR "lockedWinnerDriverId" IS NULL
+        OR "lockedDnfDriverId" IS NULL)
   `
   const targetCount = Number(before[0]?.count ?? 0)
-  console.log(`Locked PickSets needing snapshot backfill: ${targetCount}`)
+  console.log(`Locked PickSets needing driver snapshot backfill: ${targetCount}`)
 
   if (targetCount === 0) {
     console.log('Nothing to do.')
@@ -36,7 +38,9 @@ async function main() {
         "lockedDnfDriverId"        = "dnfDriverId",
         "lockedDnfSeatKey"         = "dnfSeatKey"
     WHERE "lockedAt" IS NOT NULL
-      AND "lockedTenthPlaceDriverId" IS NULL
+      AND ("lockedTenthPlaceDriverId" IS NULL
+        OR "lockedWinnerDriverId" IS NULL
+        OR "lockedDnfDriverId" IS NULL)
   `
 
   console.log(`Backfilled ${Number(updated)} row(s).`)


### PR DESCRIPTION
Closes #300

## Summary
- Target locked pick sets when any locked driver snapshot is missing, not only `lockedTenthPlaceDriverId`.
- Backfill the full locked driver/seat snapshot set for those partial rows.
- Add static coverage for partial locked snapshot predicates and wire it into `test:scripts:static`.

## Test Plan
- [x] Red cycle: new backfill snapshot test failed before implementation
- [x] `node --test scripts/backfill-locked-snapshots.test.mjs`
- [x] `npm run test:scripts:static`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `git diff --check`
- [x] Focused subagent review: spec ✅, quality approved

— gib