### PR TITLE
Guard sprint orphan cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:pages": "node --test 'src/app/(main)/dynamic-pages.test.mjs' 'src/app/(main)/races/race-detail-page.test.mjs' 'src/app/(auth)/onboarding/username/page.test.mjs' 'src/app/(main)/leaderboard/search-params.test.mjs' src/app/privacy/page.test.mjs",
     "test:utils": "node --test src/lib/utils.test.mjs src/lib/observability/client-errors.test.mjs",
     "test:scoring": "node --test src/lib/scoring/formula.test.mjs",
-    "test:scripts:static": "node --test scripts/backfill-locked-snapshots.test.mjs scripts/db-entrypoint.test.mjs scripts/find-cheated-picks.test.mjs scripts/install-pickset-triggers.test.mjs scripts/maintenance-season-guards.test.mjs scripts/tsconfig-prisma-coverage.test.mjs scripts/vercel-cli-doc.test.mjs",
+    "test:scripts:static": "node --test scripts/backfill-locked-snapshots.test.mjs scripts/cleanup-orphaned-races.test.mjs scripts/db-entrypoint.test.mjs scripts/find-cheated-picks.test.mjs scripts/install-pickset-triggers.test.mjs scripts/maintenance-season-guards.test.mjs scripts/tsconfig-prisma-coverage.test.mjs scripts/vercel-cli-doc.test.mjs",
     "test:services": "node --test src/lib/services/pick.service.test.mjs src/lib/services/race.service.test.mjs src/lib/services/race-summary.mapper.test.mjs src/lib/services/user.service.test.mjs src/lib/services/leaderboard-rank.test.mjs src/lib/services/friendship.service.test.mjs src/lib/f1/providers/openf1.test.mjs",
     "lint": "next lint",
     "db:push": "prisma db push",

--- a/scripts/cleanup-orphaned-races.test.mjs
+++ b/scripts/cleanup-orphaned-races.test.mjs
@@ -1,0 +1,23 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const source = await readFile(new URL("./cleanup-orphaned-races.ts", import.meta.url), "utf8")
+const sprintFetchIndex = source.indexOf("const sprintSessions = await fetchOpenF1<OpenF1Session>")
+const passOneIndex = source.indexOf("// ─── Pass 1: orphan reconciliation")
+const sprintBranchIndex = source.indexOf("} else if (r.type === 'SPRINT') {")
+const sprintOrphanReasonIndex = source.indexOf("OpenF1 has \"${matched")
+
+assert.notEqual(sprintFetchIndex, -1, "expected sprint session fetch")
+assert.notEqual(passOneIndex, -1, "expected Pass 1 section")
+assert.notEqual(sprintBranchIndex, -1, "expected sprint orphan branch")
+assert.notEqual(sprintOrphanReasonIndex, -1, "expected sprint orphan push")
+
+test("sprint orphan cleanup is skipped when OpenF1 sprint sessions look partial", () => {
+  const beforePassOne = source.slice(sprintFetchIndex, passOneIndex)
+  assert.match(beforePassOne, /const canReconcileSprints = sprintSessions\.length > 0/)
+  assert.match(beforePassOne, /sprint orphan reconciliation disabled/)
+
+  const sprintBranch = source.slice(sprintBranchIndex, sprintOrphanReasonIndex)
+  assert.match(sprintBranch, /if \(!canReconcileSprints\) \{\s*continue\s*\}/)
+})

--- a/scripts/cleanup-orphaned-races.ts
+++ b/scripts/cleanup-orphaned-races.ts
@@ -23,6 +23,9 @@
  *
  * Refuses to act when OpenF1 returns fewer than 10 meetings (probable
  * upstream outage / partial response).
+ * Skips destructive SPRINT orphaning when OpenF1 returns zero Sprint
+ * sessions, because that is more likely partial session data than proof
+ * that every sprint weekend disappeared.
  *
  * Status is flipped, not deleted, because PickSet → Race cascades.
  * CANCELLED rows are silently hidden by both web RacesListClient and iOS
@@ -114,6 +117,12 @@ async function main() {
   console.log(
     `OpenF1 reports ${sprintSessions.length} Sprint session(s) across ${sprintMeetingKeys.size} meeting(s).`,
   )
+  const canReconcileSprints = sprintSessions.length > 0
+  if (!canReconcileSprints) {
+    console.warn(
+      'OpenF1 returned zero Sprint sessions; sprint orphan reconciliation disabled for this run.',
+    )
+  }
 
   // For Pass 1 we don't need /sessions wholesale — only sprint sessions above
   // — but Pass 2 wants the full session set to verify openf1SessionKey.
@@ -161,6 +170,9 @@ async function main() {
         })
       }
     } else if (r.type === 'SPRINT') {
+      if (!canReconcileSprints) {
+        continue
+      }
       const root = r.name.replace(/\s*Sprint\s*$/i, '').trim()
       if (!root) continue
       // Match DB sprint root against OpenF1 meeting name; e.g. "Canadian" vs


### PR DESCRIPTION
Closes #301

## Summary
- Disable destructive SPRINT orphan reconciliation when OpenF1 returns zero Sprint sessions.
- Keep MAIN orphan reconciliation and the read-only drift audit running.
- Add static coverage for the sprint partial-session guard and wire it into `test:scripts:static`.

## Test Plan
- [x] Red cycle: new cleanup-orphaned-races test failed before implementation
- [x] `node --test scripts/cleanup-orphaned-races.test.mjs`
- [x] `npm run test:scripts:static`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `git diff --check`
- [x] Focused subagent review: spec ✅, quality approved

— gib