### PR TITLE
Defer zero-row qualifying retries

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:utils": "node --test src/lib/utils.test.mjs src/lib/observability/client-errors.test.mjs",
     "test:scoring": "node --test src/lib/scoring/formula.test.mjs",
     "test:scripts:static": "node --test scripts/backfill-locked-snapshots.test.mjs scripts/cleanup-orphaned-races.test.mjs scripts/db-entrypoint.test.mjs scripts/find-cheated-picks.test.mjs scripts/install-pickset-triggers.test.mjs scripts/maintenance-season-guards.test.mjs scripts/tsconfig-prisma-coverage.test.mjs scripts/vercel-cli-doc.test.mjs",
-    "test:services": "node --test src/lib/services/pick.service.test.mjs src/lib/services/race.service.test.mjs src/lib/services/race-summary.mapper.test.mjs src/lib/services/user.service.test.mjs src/lib/services/leaderboard-rank.test.mjs src/lib/services/friendship.service.test.mjs src/lib/f1/providers/openf1.test.mjs",
+    "test:services": "node --test src/lib/services/pick.service.test.mjs src/lib/services/race.service.test.mjs src/lib/services/race-summary.mapper.test.mjs src/lib/services/user.service.test.mjs src/lib/services/leaderboard-rank.test.mjs src/lib/services/friendship.service.test.mjs src/lib/services/qualifying.service.test.mjs src/lib/f1/providers/openf1.test.mjs",
     "lint": "next lint",
     "db:push": "prisma db push",
     "db:studio": "prisma studio",

--- a/src/lib/services/qualifying.service.test.mjs
+++ b/src/lib/services/qualifying.service.test.mjs
@@ -1,0 +1,23 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const source = await readFile(new URL("./qualifying.service.ts", import.meta.url), "utf8")
+
+const targetQuery = source.match(
+  /export async function findRacesNeedingQualifyingIngestion[\s\S]+?return races\.map/,
+)?.[0]
+
+test("qualifying target query defers zero-row retries until qualifying has started", () => {
+  assert.ok(targetQuery, "findRacesNeedingQualifyingIngestion source not found")
+  assert.match(targetQuery, /r\."qualifyingStartUtc"\s+<=\s+NOW\(\)/)
+  assert.match(targetQuery, /q\.cnt IS NULL/)
+})
+
+test("qualifying target query preserves stale partial-row retries", () => {
+  assert.ok(targetQuery, "findRacesNeedingQualifyingIngestion source not found")
+  assert.match(
+    targetQuery,
+    /q\.cnt < 18 AND q\.last_updated < NOW\(\) - INTERVAL '15 minutes'/,
+  )
+})

--- a/src/lib/services/qualifying.service.ts
+++ b/src/lib/services/qualifying.service.ts
@@ -129,10 +129,11 @@ export async function ingestQualifyingForRace(
  * the prior bug where `getFinalResults` mis-classified eliminated drivers as
  * DNF and wrote only 7-8 rows.
  *
+ * Zero-row races are not retried until their paired qualifying session start
+ * has passed, because a provider empty response leaves no persisted marker.
  * A 15-minute throttle on partial races prevents the 5-minute cron from
  * churning OpenF1 for sessions that legitimately have a small grid (testing,
- * sprint formats, etc.) — once a re-ingest attempt completes (success or
- * provider returning 0 rows), we don't retry until the throttle clears.
+ * sprint formats, etc.).
  */
 export async function findRacesNeedingQualifyingIngestion(): Promise<string[]> {
   const fourteenDaysAgo = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000)
@@ -147,6 +148,7 @@ export async function findRacesNeedingQualifyingIngestion(): Promise<string[]> {
       GROUP BY "raceId"
     ) q ON q."raceId" = r.id
     WHERE r."openf1QualifyingSessionKey" IS NOT NULL
+      AND r."qualifyingStartUtc" <= NOW()
       AND r."scheduledStartUtc" > ${fourteenDaysAgo}
       AND (
         q.cnt IS NULL


### PR DESCRIPTION
## Summary
- defer zero-row qualifying retries until the paired qualifying session start has passed
- preserve stale partial-row qualifying retries through the existing 15-minute throttle
- add source-level regression coverage for the qualifying candidate query

Closes #303
Refs #274

## Test Plan
- [x] `node --test src/lib/services/qualifying.service.test.mjs`
- [x] `npm run test:services`
- [x] `npm run test:routes`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `git diff --check`
- [x] Subagent review: spec pass, quality pass, no findings

— gib
