### PR TITLE
Preserve locked scoring seat snapshots

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:utils": "node --test src/lib/utils.test.mjs src/lib/observability/client-errors.test.mjs",
     "test:scoring": "node --test src/lib/scoring/formula.test.mjs",
     "test:scripts:static": "node --test scripts/backfill-locked-snapshots.test.mjs scripts/cleanup-orphaned-races.test.mjs scripts/db-entrypoint.test.mjs scripts/find-cheated-picks.test.mjs scripts/install-pickset-triggers.test.mjs scripts/maintenance-season-guards.test.mjs scripts/tsconfig-prisma-coverage.test.mjs scripts/vercel-cli-doc.test.mjs",
-    "test:services": "node --test src/lib/services/pick.service.test.mjs src/lib/services/race.service.test.mjs src/lib/services/race-summary.mapper.test.mjs src/lib/services/user.service.test.mjs src/lib/services/leaderboard-rank.test.mjs src/lib/services/friendship.service.test.mjs src/lib/services/qualifying.service.test.mjs src/lib/f1/providers/openf1.test.mjs",
+    "test:services": "node --test src/lib/services/pick.service.test.mjs src/lib/services/race.service.test.mjs src/lib/services/race-summary.mapper.test.mjs src/lib/services/user.service.test.mjs src/lib/services/leaderboard-rank.test.mjs src/lib/services/friendship.service.test.mjs src/lib/services/qualifying.service.test.mjs src/lib/services/scoring-pick-resolution.test.mjs src/lib/services/scoring.service.test.mjs src/lib/f1/providers/openf1.test.mjs",
     "lint": "next lint",
     "db:push": "prisma db push",
     "db:studio": "prisma studio",

--- a/src/lib/services/scoring-pick-resolution.test.mjs
+++ b/src/lib/services/scoring-pick-resolution.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import test from "node:test"
+import ts from "typescript"
+
+async function loadResolutionModule() {
+  const source = await readFile(
+    new URL("./scoring-pick-resolution.ts", import.meta.url),
+    "utf8",
+  )
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2022,
+    },
+  })
+  const encoded = Buffer.from(outputText).toString("base64")
+  return import(`data:text/javascript;base64,${encoded}`)
+}
+
+const { resolveSeatKeyForScoring } = await loadResolutionModule()
+
+test("locked picks keep a stored locked seat key without live inference", () => {
+  let inferred = false
+
+  const seatKey = resolveSeatKeyForScoring({
+    storedSeatKey: "ferrari:44",
+    lockedDriverId: "driver-44",
+    inferSeatKeyFromLiveDriver: () => {
+      inferred = true
+      return "live:1"
+    },
+  })
+
+  assert.equal(seatKey, "ferrari:44")
+  assert.equal(inferred, false)
+})
+
+test("locked picks without a stored seat key fall back to locked driver id", () => {
+  let inferred = false
+
+  const seatKey = resolveSeatKeyForScoring({
+    storedSeatKey: null,
+    lockedDriverId: "driver-44",
+    inferSeatKeyFromLiveDriver: () => {
+      inferred = true
+      return "live:1"
+    },
+  })
+
+  assert.equal(seatKey, null)
+  assert.equal(inferred, false)
+})
+
+test("unlocked picks may infer a seat key from the live relation", () => {
+  const seatKey = resolveSeatKeyForScoring({
+    storedSeatKey: null,
+    lockedDriverId: null,
+    inferSeatKeyFromLiveDriver: () => "live:1",
+  })
+
+  assert.equal(seatKey, "live:1")
+})

--- a/src/lib/services/scoring-pick-resolution.ts
+++ b/src/lib/services/scoring-pick-resolution.ts
@@ -1,0 +1,13 @@
+export function resolveSeatKeyForScoring({
+  storedSeatKey,
+  lockedDriverId,
+  inferSeatKeyFromLiveDriver,
+}: {
+  storedSeatKey: string | null
+  lockedDriverId: string | null
+  inferSeatKeyFromLiveDriver: () => string | null
+}): string | null {
+  if (storedSeatKey) return storedSeatKey
+  if (lockedDriverId !== null) return null
+  return inferSeatKeyFromLiveDriver()
+}

--- a/src/lib/services/scoring.service.test.mjs
+++ b/src/lib/services/scoring.service.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import test from "node:test"
+
+const source = await readFile(new URL("./scoring.service.ts", import.meta.url), "utf8")
+
+const bulkScoringBody = source.match(
+  /export async function computeAndStoreScoresForRace[\s\S]+?export async function recomputeScoreForPickSet/,
+)?.[0]
+
+const singlePickBody = source.match(
+  /export async function recomputeScoreForPickSet[\s\S]+$/,
+)?.[0]
+
+test("bulk scoring resolves locked seat keys without live-driver inference", () => {
+  assert.ok(bulkScoringBody, "computeAndStoreScoresForRace source not found")
+  assert.match(
+    bulkScoringBody,
+    /resolveSeatKey\(\s*f\.tenthPlaceSeatKey,\s*f\.lockedTenthPlaceDriverId,\s*pickSet\.tenthPlaceDriver,\s*\)/,
+  )
+  assert.match(
+    bulkScoringBody,
+    /resolveSeatKey\(\s*f\.winnerSeatKey,\s*f\.lockedWinnerDriverId,\s*pickSet\.winnerDriver,\s*\)/,
+  )
+  assert.match(
+    bulkScoringBody,
+    /resolveSeatKey\(\s*f\.dnfSeatKey,\s*f\.lockedDnfDriverId,\s*pickSet\.dnfDriver,\s*\)/,
+  )
+})
+
+test("single-pick recompute resolves locked seat keys without live-driver inference", () => {
+  assert.ok(singlePickBody, "recomputeScoreForPickSet source not found")
+  assert.match(
+    singlePickBody,
+    /resolveSeatKey\(\s*tenthSeatKey,\s*ps\.lockedTenthPlaceDriverId,\s*ps\.tenthPlaceDriver,\s*\)/,
+  )
+  assert.match(
+    singlePickBody,
+    /resolveSeatKey\(\s*winnerSeatKey,\s*ps\.lockedWinnerDriverId,\s*ps\.winnerDriver,\s*\)/,
+  )
+  assert.match(
+    singlePickBody,
+    /resolveSeatKey\(\s*dnfSeatKey,\s*ps\.lockedDnfDriverId,\s*ps\.dnfDriver,\s*\)/,
+  )
+})

--- a/src/lib/services/scoring.service.ts
+++ b/src/lib/services/scoring.service.ts
@@ -16,6 +16,7 @@ import type { ScoreBreakdownData } from '@/types/domain'
 import type { NormalizedFinalResult } from '@/lib/f1/types'
 import { buildSeatLookup, inferSeatKeyFromDriver } from '@/lib/f1/seats'
 import { resolveTeam } from '@/lib/f1/teams'
+import { resolveSeatKeyForScoring } from './scoring-pick-resolution'
 
 /**
  * A Prisma client capable of running our queries — either the global `db`
@@ -49,6 +50,7 @@ function toSeatAwareDriver(driver: {
 
 function resolveSeatKey(
   storedSeatKey: string | null,
+  lockedDriverId: string | null,
   driver: {
     id: string
     code: string
@@ -60,8 +62,12 @@ function resolveSeatKey(
     }
   },
 ): string | null {
-  if (storedSeatKey) return storedSeatKey
-  return inferSeatKeyFromDriver(toSeatAwareDriver(driver))
+  return resolveSeatKeyForScoring({
+    storedSeatKey,
+    lockedDriverId,
+    inferSeatKeyFromLiveDriver: () =>
+      inferSeatKeyFromDriver(toSeatAwareDriver(driver)),
+  })
 }
 
 function resolveEffectiveDriverId(
@@ -165,17 +171,20 @@ export async function computeAndStoreScoresForRace(
   // This guarantees scoring uses the pre-lock state even if a post-lock write
   // somehow lands on the live fields.
   const pickFields = (ps: (typeof pickSets)[number]) => ({
+    lockedTenthPlaceDriverId: ps.lockedTenthPlaceDriverId,
     tenthPlaceDriverId:
       ps.lockedTenthPlaceDriverId ?? ps.tenthPlaceDriverId,
     tenthPlaceSeatKey:
       ps.lockedTenthPlaceDriverId !== null
         ? ps.lockedTenthPlaceSeatKey
         : ps.tenthPlaceSeatKey,
+    lockedWinnerDriverId: ps.lockedWinnerDriverId,
     winnerDriverId: ps.lockedWinnerDriverId ?? ps.winnerDriverId,
     winnerSeatKey:
       ps.lockedWinnerDriverId !== null
         ? ps.lockedWinnerSeatKey
         : ps.winnerSeatKey,
+    lockedDnfDriverId: ps.lockedDnfDriverId,
     dnfDriverId: ps.lockedDnfDriverId ?? ps.dnfDriverId,
     dnfSeatKey:
       ps.lockedDnfDriverId !== null ? ps.lockedDnfSeatKey : ps.dnfSeatKey,
@@ -188,19 +197,31 @@ export async function computeAndStoreScoresForRace(
       tenthPlaceDriverId: resolveEffectiveDriverId(
         entrantLookup.seatKeyToDriverId,
         entrantIds,
-        resolveSeatKey(f.tenthPlaceSeatKey, pickSet.tenthPlaceDriver),
+        resolveSeatKey(
+          f.tenthPlaceSeatKey,
+          f.lockedTenthPlaceDriverId,
+          pickSet.tenthPlaceDriver,
+        ),
         f.tenthPlaceDriverId,
       ),
       winnerDriverId: resolveEffectiveDriverId(
         entrantLookup.seatKeyToDriverId,
         entrantIds,
-        resolveSeatKey(f.winnerSeatKey, pickSet.winnerDriver),
+        resolveSeatKey(
+          f.winnerSeatKey,
+          f.lockedWinnerDriverId,
+          pickSet.winnerDriver,
+        ),
         f.winnerDriverId,
       ),
       dnfDriverId: resolveEffectiveDriverId(
         entrantLookup.seatKeyToDriverId,
         entrantIds,
-        resolveSeatKey(f.dnfSeatKey, pickSet.dnfDriver),
+        resolveSeatKey(
+          f.dnfSeatKey,
+          f.lockedDnfDriverId,
+          pickSet.dnfDriver,
+        ),
         f.dnfDriverId,
       ),
       // Early-bird snapshot — null on legacy rows is treated as false.
@@ -385,19 +406,31 @@ export async function recomputeScoreForPickSet(
     tenthPlaceDriverId: resolveEffectiveDriverId(
       entrantLookup.seatKeyToDriverId,
       entrantIds,
-      resolveSeatKey(tenthSeatKey, ps.tenthPlaceDriver),
+      resolveSeatKey(
+        tenthSeatKey,
+        ps.lockedTenthPlaceDriverId,
+        ps.tenthPlaceDriver,
+      ),
       tenthDriverId,
     ),
     winnerDriverId: resolveEffectiveDriverId(
       entrantLookup.seatKeyToDriverId,
       entrantIds,
-      resolveSeatKey(winnerSeatKey, ps.winnerDriver),
+      resolveSeatKey(
+        winnerSeatKey,
+        ps.lockedWinnerDriverId,
+        ps.winnerDriver,
+      ),
       winnerDriverId,
     ),
     dnfDriverId: resolveEffectiveDriverId(
       entrantLookup.seatKeyToDriverId,
       entrantIds,
-      resolveSeatKey(dnfSeatKey, ps.dnfDriver),
+      resolveSeatKey(
+        dnfSeatKey,
+        ps.lockedDnfDriverId,
+        ps.dnfDriver,
+      ),
       dnfDriverId,
     ),
   }


### PR DESCRIPTION
## Summary
- prevent locked scoring snapshots from inferring missing locked seat keys from live driver relations
- preserve stored locked seat keys and unlocked live-seat inference
- cover the shared policy plus bulk and single-pick recompute wiring

Closes #305
Refs #274

## Test Plan
- [x] `node --test src/lib/services/scoring-pick-resolution.test.mjs`
- [x] `node --test src/lib/services/scoring.service.test.mjs`
- [x] `npm run test:services`
- [x] `npm run test:scoring`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `git diff --check`
- [x] Subagent review: spec pass, quality pass, no findings

— gib
