### PR TITLE
Model nullable P10 hero results

### DIFF
--- a/src/app/(main)/races/[raceId]/page.tsx
+++ b/src/app/(main)/races/[raceId]/page.tsx
@@ -99,7 +99,7 @@ export default async function RacePickPage({
 
           if (!winnerDriver) return undefined
           return {
-            tenthPlace: tenthDriver ? { driver: tenthDriver, position: 10 } : null!,
+            tenthPlace: tenthDriver ? { driver: tenthDriver, position: 10 } : null,
             winner: { driver: winnerDriver },
             dnf: dnfDriver ? { driver: dnfDriver } : null,
           }

--- a/src/app/(main)/races/race-detail-page.test.mjs
+++ b/src/app/(main)/races/race-detail-page.test.mjs
@@ -8,3 +8,11 @@ test("race detail sign-in callback URL encodes the dynamic race id path", () => 
   assert.match(source, /encodeURIComponent\(`\/races\/\$\{params\.raceId\}`\)/)
   assert.doesNotMatch(source, /href=\{`\/signin\?callbackUrl=\/races\/\$\{params\.raceId\}`\}/)
 })
+
+test("race detail passes nullable completed-race P10 hero results without assertions", () => {
+  assert.match(
+    source,
+    /tenthPlace:\s*tenthDriver \? \{ driver: tenthDriver, position: 10 \} : null/,
+  )
+  assert.doesNotMatch(source, /null!/)
+})

--- a/src/components/race/HeroVisualization.test.mjs
+++ b/src/components/race/HeroVisualization.test.mjs
@@ -7,3 +7,16 @@ const source = await readFile(new URL("./HeroVisualization.tsx", import.meta.url
 test("HeroVisualization does not import unused class-name helper", () => {
   assert.doesNotMatch(source, /import \{ cn \} from ['"]@\/lib\/utils['"]/)
 })
+
+test("HeroVisualization models a missing completed P10 result as nullable", () => {
+  assert.match(
+    source,
+    /tenthPlace:\s*\{\s*driver:\s*DriverSummary;\s*position:\s*number\s*\}\s*\|\s*null/,
+  )
+  assert.match(source, /results\?\.tenthPlace\?\.driver/)
+})
+
+test("HeroVisualization renders a non-pending placeholder for missing completed results", () => {
+  assert.match(source, /const isMissingCompletedResult = isCompleted && !resultDriver/)
+  assert.match(source, /pending=\{isPending && !isMissingCompletedResult\}/)
+})

--- a/src/components/race/HeroVisualization.tsx
+++ b/src/components/race/HeroVisualization.tsx
@@ -18,7 +18,7 @@ type HeroVisualizationProps = {
   pick: SerializedPickSetWithScore | null
   /** Populated once race is completed */
   results?: {
-    tenthPlace: { driver: DriverSummary; position: number }
+    tenthPlace: { driver: DriverSummary; position: number } | null
     winner: { driver: DriverSummary }
     dnf: { driver: DriverSummary } | null
   }
@@ -137,6 +137,7 @@ function SlotColumn({
   const isLive = raceStatus === RaceStatus.LIVE
   const isCompleted = raceStatus === RaceStatus.COMPLETED
   const isPending = !isLive && !isCompleted
+  const isMissingCompletedResult = isCompleted && !resultDriver
 
   return (
     <div className="flex flex-col items-center gap-1.5">
@@ -149,7 +150,7 @@ function SlotColumn({
       <DriverBubble
         driver={resultDriver}
         size={resultSize}
-        pending={isPending}
+        pending={isPending && !isMissingCompletedResult}
         showCode={!!resultDriver}
       />
 


### PR DESCRIPTION
## Summary
- model completed-race P10 hero results as nullable
- remove the `null!` assertion from race detail hero result construction
- render missing completed P10 data as an explicit non-pending placeholder

Closes #306
Refs #274

## Test Plan
- [x] `node --test src/components/race/HeroVisualization.test.mjs`
- [x] `node --test 'src/app/(main)/races/race-detail-page.test.mjs'`
- [x] `npm run test:components`
- [x] `npm run test:pages`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `git diff --check`
- [x] Subagent review: spec pass, quality pass, no findings

— gib
