### PR TITLE
Surface username availability HTTP failures

### DIFF
--- a/src/app/(auth)/onboarding/username/page.test.mjs
+++ b/src/app/(auth)/onboarding/username/page.test.mjs
@@ -16,3 +16,10 @@ test("onboarding username suggestions ignore non-success and malformed payloads"
   assert.match(page, /Array\.isArray\(suggestions\)/)
   assert.doesNotMatch(page, /setSuggestions\(data\.suggestions\)/)
 })
+
+test("onboarding username availability treats HTTP failures as verification errors", () => {
+  assert.match(
+    page,
+    /const res = await fetch\([\s\S]+?\)\s+if \(!res\.ok\) throw new Error\("Couldn't verify username\. Please try again\."\)\s+const data/,
+  )
+})

--- a/src/app/(auth)/onboarding/username/page.tsx
+++ b/src/app/(auth)/onboarding/username/page.tsx
@@ -78,6 +78,8 @@ export default function UsernameOnboardingPage() {
         const res = await fetch(
           `/api/users/username?username=${encodeURIComponent(value)}`,
         )
+        if (!res.ok) throw new Error("Couldn't verify username. Please try again.")
+
         const data: { available: boolean } = await res.json()
         if (availabilityRequestRef.current !== requestId) return
         setIsAvailable(data.available)

--- a/src/app/(main)/profile/UsernameChangeForm.tsx
+++ b/src/app/(main)/profile/UsernameChangeForm.tsx
@@ -31,6 +31,8 @@ export function UsernameChangeForm({ currentUsername }: { currentUsername: strin
     debounce.current = setTimeout(async () => {
       try {
         const res = await fetch(`/api/users/username?username=${encodeURIComponent(value)}`)
+        if (!res.ok) throw new Error("Couldn't verify username. Please try again.")
+
         const data: { available: boolean } = await res.json()
         if (availabilityRequestRef.current !== requestId) return
         setIsAvailable(data.available)

--- a/src/app/(main)/profile/UsernameSetForm.tsx
+++ b/src/app/(main)/profile/UsernameSetForm.tsx
@@ -31,6 +31,8 @@ export function UsernameSetForm() {
     debounce.current = setTimeout(async () => {
       try {
         const res = await fetch(`/api/users/username?username=${encodeURIComponent(value)}`)
+        if (!res.ok) throw new Error("Couldn't verify username. Please try again.")
+
         const data: { available: boolean } = await res.json()
         if (availabilityRequestRef.current !== requestId) return
         setIsAvailable(data.available)

--- a/src/app/(main)/profile/profile-async-guards.test.mjs
+++ b/src/app/(main)/profile/profile-async-guards.test.mjs
@@ -15,6 +15,16 @@ test("username availability checks ignore stale async responses", async () => {
   }
 })
 
+test("username availability checks treat HTTP failures as verification errors", async () => {
+  for (const path of ["./UsernameSetForm.tsx", "./UsernameChangeForm.tsx"]) {
+    const text = await source(path)
+    assert.match(
+      text,
+      /const res = await fetch\([\s\S]+?\)\s+if \(!res\.ok\) throw new Error\("Couldn't verify username\. Please try again\."\)\s+const data/,
+    )
+  }
+})
+
 test("team picker ignores stale async save responses", async () => {
   const text = await source("./TeamPicker.tsx")
   assert.match(text, /saveRequestRef = React\.useRef\(0\)/)


### PR DESCRIPTION
## Summary
- check username availability HTTP status before parsing `available`
- route failed availability checks to the existing verification error message
- add coverage for onboarding and profile username availability failures

Closes #307
Refs #274

## Test Plan
- [x] `node --test 'src/app/(auth)/onboarding/username/page.test.mjs'`
- [x] `node --test 'src/app/(main)/profile/profile-async-guards.test.mjs'`
- [x] `npm run test:components`
- [x] `npm run test:pages`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `git diff --check`
- [x] Subagent review: spec pass, quality pass, no findings

— gib
