### PR TITLE
Separate public profile API failure state

### DIFF
--- a/src/app/(main)/profile/[userId]/page.tsx
+++ b/src/app/(main)/profile/[userId]/page.tsx
@@ -78,7 +78,22 @@ type DetailState = {
   driver: SlotDriver
 } | null
 
-const fetcher = (url: string) => fetch(url).then((r) => r.json())
+class ProfileApiError extends Error {
+  constructor(readonly status: number) {
+    super(status === 404 ? 'Profile not found' : 'Profile request failed')
+    this.name = 'ProfileApiError'
+  }
+}
+
+const fetcher = async (url: string): Promise<ProfileData> => {
+  const response = await fetch(url)
+
+  if (!response.ok) {
+    throw new ProfileApiError(response.status)
+  }
+
+  return response.json()
+}
 
 function totalScore(picks: PickEntry[]): number {
   return picks.reduce((sum, p) => sum + (p.scoreBreakdown?.totalScore ?? 0), 0)
@@ -286,11 +301,12 @@ function Section({
 
 export default function FriendProfilePage() {
   const { userId } = useParams<{ userId: string }>()
-  const { data, isLoading, error } = useSWR<ProfileData>(
+  const { data, isLoading, error } = useSWR<ProfileData, Error>(
     userId ? `/api/users/${encodeURIComponent(userId)}` : null,
     fetcher,
   )
   const [selectedDetail, setSelectedDetail] = React.useState<DetailState>(null)
+  const notFound = error instanceof ProfileApiError && error.status === 404
 
   if (isLoading) {
     return (
@@ -304,10 +320,21 @@ export default function FriendProfilePage() {
     )
   }
 
-  if (error || !data?.user) {
+  if (notFound) {
     return (
       <div className="px-4 pb-6 pt-4">
         <p className="py-12 text-center text-sm text-text-secondary">Player not found.</p>
+      </div>
+    )
+  }
+
+  if (error || !data?.user) {
+    return (
+      <div className="px-4 pb-6 pt-4">
+        <div className="rounded-2xl border border-[var(--border)] bg-surface p-6 text-center">
+          <p className="text-sm font-semibold text-text-primary">Unable to load profile.</p>
+          <p className="mt-1 text-xs text-text-secondary">Please try again shortly.</p>
+        </div>
       </div>
     )
   }

--- a/src/app/(main)/profile/profile-async-guards.test.mjs
+++ b/src/app/(main)/profile/profile-async-guards.test.mjs
@@ -49,3 +49,19 @@ test("friend profile header passes API avatar URLs to Avatar", async () => {
     "profile header should render the avatar URL returned by the API",
   )
 })
+
+test("friend profile fetcher preserves non-OK HTTP status", async () => {
+  const text = await source("./[userId]/page.tsx")
+
+  assert.match(text, /class ProfileApiError extends Error/)
+  assert.match(text, /if \(!response\.ok\) {[\s\S]*throw new ProfileApiError\(response\.status/)
+  assert.doesNotMatch(text, /fetch\(url\)\.then\(\(r\) => r\.json\(\)\)/)
+})
+
+test("friend profile renders not-found separately from API failures", async () => {
+  const text = await source("./[userId]/page.tsx")
+
+  assert.match(text, /const notFound = error instanceof ProfileApiError && error\.status === 404/)
+  assert.match(text, /if \(notFound\) {[\s\S]*Player not found\./)
+  assert.match(text, /if \(error \|\| !data\?\.user\) {[\s\S]*Unable to load profile\./)
+})


### PR DESCRIPTION
## Summary

- Make the public profile SWR fetcher throw a status-preserving error on non-OK responses
- Keep 404 responses mapped to `Player not found.`
- Render API/transient failures and malformed successful payloads as a separate load-failure state
- Add focused profile guard coverage

Closes #309

## Test Plan

- [x] `node --test 'src/app/(main)/profile/profile-async-guards.test.mjs'`
- [x] `npm run test:components`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `git diff --check`
- [x] Subagent review approved with no fix findings

— gib
