### PR TITLE
Replace stale UI source tests

### DIFF
--- a/src/components/picks/PicksDisplay.test.mjs
+++ b/src/components/picks/PicksDisplay.test.mjs
@@ -1,10 +1,27 @@
 import test from "node:test"
 import assert from "node:assert/strict"
-import { readFile } from "node:fs/promises"
 
-const source = await readFile(new URL("./PicksDisplay.tsx", import.meta.url), "utf8")
+import {
+  actualResultLabel,
+  formatScoreChip,
+  scoreTone,
+  totalScoreFromBreakdown,
+} from "./picks-display-view.mjs"
 
-test("PicksDisplay does not carry unused maxScore row props", () => {
-  assert.doesNotMatch(source, /getScoringCaps/)
-  assert.doesNotMatch(source, /maxScore/)
+test("PicksDisplay renders score chips from actual score values", () => {
+  assert.equal(scoreTone(8), "positive")
+  assert.equal(scoreTone(0), "neutral")
+  assert.equal(formatScoreChip(8), "+8")
+  assert.equal(formatScoreChip(0), "+0")
+})
+
+test("PicksDisplay formats actual result labels for classified and non-finish rows", () => {
+  assert.equal(actualResultLabel({ driverId: "driver-1", position: 10, status: "CLASSIFIED" }), "P10")
+  assert.equal(actualResultLabel({ driverId: "driver-1", position: null, status: "DNF" }), "DNF")
+  assert.equal(actualResultLabel(null), "—")
+})
+
+test("PicksDisplay falls back to zero total when a completed pick is unscored", () => {
+  assert.equal(totalScoreFromBreakdown({ totalScore: 18 }), 18)
+  assert.equal(totalScoreFromBreakdown(null), 0)
 })

--- a/src/components/picks/PicksDisplay.tsx
+++ b/src/components/picks/PicksDisplay.tsx
@@ -2,6 +2,12 @@ import * as React from 'react'
 import { ArrowRight, Trophy, Target, AlertCircle } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
+import {
+  actualResultLabel,
+  formatScoreChip,
+  scoreTone,
+  totalScoreFromBreakdown,
+} from '@/components/picks/picks-display-view.mjs'
 import type { SerializedPickSetWithScore, SerializedRaceSummary, DriverSummary } from '@/types/domain'
 import { RaceStatus } from '@/types/domain'
 
@@ -13,6 +19,10 @@ type ResultRow = {
   driverId: string
   position: number | null
   status: string
+}
+
+function scoreToneClass(score: number): string {
+  return scoreTone(score) === 'positive' ? 'text-[#30d158]' : 'text-text-tertiary'
 }
 
 interface PicksDisplayProps {
@@ -42,8 +52,6 @@ function CategoryRow({
   actualResult,
   score,
 }: CategoryRowProps) {
-  const scored = score > 0
-
   return (
     <div className="flex items-center gap-3 py-3 border-b border-[var(--border)] last:border-0">
       {/* Category icon + label */}
@@ -62,21 +70,17 @@ function CategoryRow({
 
       {/* Actual result */}
       <span className="text-sm text-text-secondary w-12 truncate text-center">
-        {actualResult
-          ? actualResult.position !== null
-            ? `P${actualResult.position}`
-            : actualResult.status
-          : '—'}
+        {actualResultLabel(actualResult)}
       </span>
 
       {/* Score chip */}
       <span
         className={cn(
           'text-sm font-bold w-10 text-right shrink-0',
-          scored ? 'text-[#30d158]' : 'text-text-tertiary',
+          scoreToneClass(score),
         )}
       >
-        +{score}
+        {formatScoreChip(score)}
       </span>
     </div>
   )
@@ -125,7 +129,7 @@ export function PicksDisplay({ pick, race, results, entrants = [] }: PicksDispla
   const winnerResult = results.find((r) => r.driverId === pick.winnerDriverId)
   const dnfResult = results.find((r) => r.driverId === pick.dnfDriverId)
 
-  const totalScore = breakdown?.totalScore ?? 0
+  const totalScore = totalScoreFromBreakdown(breakdown)
 
   return (
     <div className="rounded-2xl bg-surface border border-[var(--border)] p-4 flex flex-col gap-4">
@@ -162,7 +166,7 @@ export function PicksDisplay({ pick, race, results, entrants = [] }: PicksDispla
         <span
           className={cn(
             'text-3xl font-bold',
-            totalScore > 0 ? 'text-[#30d158]' : 'text-text-tertiary',
+            scoreToneClass(totalScore),
           )}
         >
           {totalScore}

--- a/src/components/picks/picks-display-view.mjs
+++ b/src/components/picks/picks-display-view.mjs
@@ -1,0 +1,16 @@
+export function scoreTone(score) {
+  return score > 0 ? "positive" : "neutral"
+}
+
+export function formatScoreChip(score) {
+  return `+${score}`
+}
+
+export function actualResultLabel(actualResult) {
+  if (!actualResult) return "—"
+  return actualResult.position !== null ? `P${actualResult.position}` : actualResult.status
+}
+
+export function totalScoreFromBreakdown(scoreBreakdown) {
+  return scoreBreakdown?.totalScore ?? 0
+}

--- a/src/components/race/HeroVisualization.test.mjs
+++ b/src/components/race/HeroVisualization.test.mjs
@@ -1,22 +1,21 @@
 import test from "node:test"
 import assert from "node:assert/strict"
-import { readFile } from "node:fs/promises"
 
-const source = await readFile(new URL("./HeroVisualization.tsx", import.meta.url), "utf8")
+import {
+  isActualResultPending,
+  isMissingCompletedResult,
+  isPickResultMatched,
+} from "./hero-visualization-view.mjs"
 
-test("HeroVisualization does not import unused class-name helper", () => {
-  assert.doesNotMatch(source, /import \{ cn \} from ['"]@\/lib\/utils['"]/)
+test("HeroVisualization treats missing completed result bubbles as resolved placeholders", () => {
+  assert.equal(isMissingCompletedResult("COMPLETED", null), true)
+  assert.equal(isActualResultPending("COMPLETED", null), false)
+  assert.equal(isActualResultPending("UPCOMING", null), true)
 })
 
-test("HeroVisualization models a missing completed P10 result as nullable", () => {
-  assert.match(
-    source,
-    /tenthPlace:\s*\{\s*driver:\s*DriverSummary;\s*position:\s*number\s*\}\s*\|\s*null/,
-  )
-  assert.match(source, /results\?\.tenthPlace\?\.driver/)
-})
-
-test("HeroVisualization renders a non-pending placeholder for missing completed results", () => {
-  assert.match(source, /const isMissingCompletedResult = isCompleted && !resultDriver/)
-  assert.match(source, /pending=\{isPending && !isMissingCompletedResult\}/)
+test("HeroVisualization only marks picks as matched against completed concrete results", () => {
+  assert.equal(isPickResultMatched("COMPLETED", "driver-1", "driver-1"), true)
+  assert.equal(isPickResultMatched("COMPLETED", "driver-1", null), false)
+  assert.equal(isPickResultMatched("LIVE", "driver-1", "driver-1"), false)
+  assert.equal(isPickResultMatched("COMPLETED", null, "driver-1"), false)
 })

--- a/src/components/race/HeroVisualization.tsx
+++ b/src/components/race/HeroVisualization.tsx
@@ -6,6 +6,10 @@ import { motion } from 'framer-motion'
 
 import { Badge } from '@/components/ui/badge'
 import { LockCountdown } from '@/components/race/LockCountdown'
+import {
+  isActualResultPending,
+  isPickResultMatched,
+} from '@/components/race/hero-visualization-view.mjs'
 import type { SerializedRaceSummary, SerializedPickSetWithScore, DriverSummary } from '@/types/domain'
 import { RaceType, RaceStatus } from '@/types/domain'
 
@@ -134,10 +138,7 @@ function SlotColumn({
   hasPick,
   matched,
 }: SlotColumnProps) {
-  const isLive = raceStatus === RaceStatus.LIVE
-  const isCompleted = raceStatus === RaceStatus.COMPLETED
-  const isPending = !isLive && !isCompleted
-  const isMissingCompletedResult = isCompleted && !resultDriver
+  const resultPending = isActualResultPending(raceStatus, resultDriver)
 
   return (
     <div className="flex flex-col items-center gap-1.5">
@@ -150,7 +151,7 @@ function SlotColumn({
       <DriverBubble
         driver={resultDriver}
         size={resultSize}
-        pending={isPending && !isMissingCompletedResult}
+        pending={resultPending}
         showCode={!!resultDriver}
       />
 
@@ -161,7 +162,7 @@ function SlotColumn({
       <DriverBubble
         driver={pickDriver ?? null}
         size={pickSize}
-        matched={matched && isCompleted}
+        matched={matched && raceStatus === RaceStatus.COMPLETED}
         empty={!hasPick}
         pending={!hasPick}
         showCode={!!pickDriver}
@@ -218,23 +219,25 @@ export function HeroVisualization({
 
   // Match checks
   const tenthMatched = Boolean(
-    isCompleted &&
-      pick &&
-      results &&
-      pick.tenthPlaceDriverId === results.tenthPlace?.driver?.id,
+    isPickResultMatched(
+      race.status,
+      pick?.tenthPlaceDriverId,
+      results?.tenthPlace?.driver?.id,
+    ),
   )
   const winnerMatched = Boolean(
-    isCompleted &&
-      pick &&
-      results &&
-      pick.winnerDriverId === results.winner?.driver?.id,
+    isPickResultMatched(
+      race.status,
+      pick?.winnerDriverId,
+      results?.winner?.driver?.id,
+    ),
   )
   const dnfMatched = Boolean(
-    isCompleted &&
-      pick &&
-      results &&
-      results.dnf &&
-      pick.dnfDriverId === results.dnf?.driver?.id,
+    isPickResultMatched(
+      race.status,
+      pick?.dnfDriverId,
+      results?.dnf?.driver?.id,
+    ),
   )
 
   return (

--- a/src/components/race/hero-visualization-view.mjs
+++ b/src/components/race/hero-visualization-view.mjs
@@ -1,0 +1,20 @@
+export function isMissingCompletedResult(raceStatus, resultDriver) {
+  return raceStatus === "COMPLETED" && !resultDriver
+}
+
+export function isActualResultPending(raceStatus, resultDriver) {
+  return (
+    raceStatus !== "LIVE" &&
+    raceStatus !== "COMPLETED" &&
+    !isMissingCompletedResult(raceStatus, resultDriver)
+  )
+}
+
+export function isPickResultMatched(raceStatus, pickDriverId, resultDriverId) {
+  return Boolean(
+    raceStatus === "COMPLETED" &&
+      pickDriverId &&
+      resultDriverId &&
+      pickDriverId === resultDriverId,
+  )
+}


### PR DESCRIPTION
## Summary

- Replace stale negative UI source tests with behavior-helper coverage
- Add small local helpers used by `HeroVisualization` and `PicksDisplay`
- Cover nullable completed result placeholders, match gating, score labels, result labels, and zero-total fallback

Closes #312

## Test Plan

- [x] `node --test src/components/race/HeroVisualization.test.mjs src/components/picks/PicksDisplay.test.mjs`
- [x] `npm run test:components`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `git diff --check`
- [x] Search confirmed the stale test names/patterns are absent
- [x] Subagent re-review approved with no findings

— gib
