### PR TITLE
fix: load env in pickset trigger smoke test

### DIFF
--- a/scripts/install-pickset-triggers.test.mjs
+++ b/scripts/install-pickset-triggers.test.mjs
@@ -6,8 +6,12 @@ const source = await readFile(
   new URL("./install-pickset-triggers.ts", import.meta.url),
   "utf8",
 )
+const smokeSource = await readFile(
+  new URL("./test-pickset-trigger.ts", import.meta.url),
+  "utf8",
+)
 
-test("trigger installer loads env files before reading DB URLs", () => {
+function assertLoadsEnvBeforeDbUrl(source, scriptName) {
   assert.match(source, /import \{ config as loadDotenv \} from ['"]dotenv['"]/)
   assert.match(source, /loadDotenv\(\{ path: ['"]\.env\.local['"] \}\)/)
   assert.match(source, /loadDotenv\(\{ path: ['"]\.env['"] \}\)/)
@@ -15,15 +19,23 @@ test("trigger installer loads env files before reading DB URLs", () => {
   const localDotenvIndex = source.indexOf("loadDotenv({ path: '.env.local' })")
   const dotenvIndex = source.indexOf("loadDotenv({ path: '.env' })")
   const directUrlIndex = source.indexOf("const directUrl =")
-  assert.ok(localDotenvIndex >= 0, "expected installer to load .env.local")
-  assert.ok(dotenvIndex >= 0, "expected installer to load .env")
-  assert.ok(directUrlIndex >= 0, "expected installer to read directUrl")
+  assert.ok(localDotenvIndex >= 0, `expected ${scriptName} to load .env.local`)
+  assert.ok(dotenvIndex >= 0, `expected ${scriptName} to load .env`)
+  assert.ok(directUrlIndex >= 0, `expected ${scriptName} to read directUrl`)
   assert.ok(
     localDotenvIndex < directUrlIndex,
-    ".env.local must load before DIRECT_URL/DATABASE_URL are read",
+    `${scriptName} must load .env.local before DIRECT_URL/DATABASE_URL are read`,
   )
   assert.ok(
     dotenvIndex < directUrlIndex,
-    ".env must load before DIRECT_URL/DATABASE_URL are read",
+    `${scriptName} must load .env before DIRECT_URL/DATABASE_URL are read`,
   )
+}
+
+test("trigger installer loads env files before reading DB URLs", () => {
+  assertLoadsEnvBeforeDbUrl(source, "trigger installer")
+})
+
+test("trigger smoke test loads env files before reading DB URLs", () => {
+  assertLoadsEnvBeforeDbUrl(smokeSource, "trigger smoke test")
 })

--- a/scripts/test-pickset-trigger.ts
+++ b/scripts/test-pickset-trigger.ts
@@ -6,7 +6,11 @@
  *
  *   npx tsx scripts/test-pickset-trigger.ts
  */
+import { config as loadDotenv } from 'dotenv'
 import { PrismaClient, Prisma } from '@prisma/client'
+
+loadDotenv({ path: '.env.local' })
+loadDotenv({ path: '.env' })
 
 const directUrl = process.env.DIRECT_URL ?? process.env.DATABASE_URL
 if (!directUrl) {


### PR DESCRIPTION
Closes #349

## Summary
- Load `.env.local` and `.env` in the pickset trigger smoke test before reading `DIRECT_URL` or `DATABASE_URL`.
- Extend static trigger-script coverage so both installer and smoke test retain dotenv loading order.

## Test Plan
- [x] `node --test scripts/install-pickset-triggers.test.mjs`
- [x] `npm run test:scripts:static`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `git diff --check`

## Review
- [x] Red test failed first for missing dotenv import in `scripts/test-pickset-trigger.ts`.
- [x] Subagent review: spec PASS, quality APPROVED, no findings.

— gib
