### PR TITLE
fix: include seat snapshots in locked backfill guards

### DIFF
--- a/scripts/backfill-locked-snapshots.test.mjs
+++ b/scripts/backfill-locked-snapshots.test.mjs
@@ -9,12 +9,16 @@ const targetQuery = source.match(
 const updateQuery = source.match(
   /const updated = await db\.\$executeRaw`([\s\S]*?)`/,
 )?.[1]
+const verificationQuery = source.match(
+  /const drift = await db\.\$queryRaw<Array<\{ count: bigint \}>>`([\s\S]*?)`/,
+)?.[1]
 
 assert.ok(targetQuery, "expected to find the target count query")
 assert.ok(updateQuery, "expected to find the snapshot update query")
+assert.ok(verificationQuery, "expected to find the post-state verification query")
 
-test("backfill targets any locked row missing a driver snapshot", () => {
-  for (const query of [targetQuery, updateQuery]) {
+test("backfill targets any locked row missing a driver or seat snapshot", () => {
+  for (const query of [targetQuery, updateQuery, verificationQuery]) {
     assert.match(query, /"lockedAt" IS NOT NULL/)
 
     for (const field of [
@@ -27,5 +31,17 @@ test("backfill targets any locked row missing a driver snapshot", () => {
 
     assert.match(query, /OR\s+"lockedWinnerDriverId" IS NULL/)
     assert.match(query, /OR\s+"lockedDnfDriverId" IS NULL/)
+
+    for (const [liveField, lockedField] of [
+      ["tenthPlaceSeatKey", "lockedTenthPlaceSeatKey"],
+      ["winnerSeatKey", "lockedWinnerSeatKey"],
+      ["dnfSeatKey", "lockedDnfSeatKey"],
+    ]) {
+      assert.match(
+        query,
+        new RegExp(`"${liveField}" IS NOT NULL[\\s\\S]*"${lockedField}" IS NULL`),
+        `${lockedField} should be checked when ${liveField} exists`,
+      )
+    }
   }
 })

--- a/scripts/backfill-locked-snapshots.ts
+++ b/scripts/backfill-locked-snapshots.ts
@@ -8,7 +8,7 @@
  *
  *   npx tsx scripts/backfill-locked-snapshots.ts
  *
- * Idempotent: WHERE clause skips rows whose driver snapshot is already populated.
+ * Idempotent: WHERE clause skips rows whose driver/seat snapshot is already populated.
  */
 import { db } from '@/lib/db/client'
 
@@ -19,10 +19,13 @@ async function main() {
     WHERE "lockedAt" IS NOT NULL
       AND ("lockedTenthPlaceDriverId" IS NULL
         OR "lockedWinnerDriverId" IS NULL
-        OR "lockedDnfDriverId" IS NULL)
+        OR "lockedDnfDriverId" IS NULL
+        OR ("tenthPlaceSeatKey" IS NOT NULL AND "lockedTenthPlaceSeatKey" IS NULL)
+        OR ("winnerSeatKey" IS NOT NULL AND "lockedWinnerSeatKey" IS NULL)
+        OR ("dnfSeatKey" IS NOT NULL AND "lockedDnfSeatKey" IS NULL))
   `
   const targetCount = Number(before[0]?.count ?? 0)
-  console.log(`Locked PickSets needing driver snapshot backfill: ${targetCount}`)
+  console.log(`Locked PickSets needing snapshot backfill: ${targetCount}`)
 
   if (targetCount === 0) {
     console.log('Nothing to do.')
@@ -40,7 +43,10 @@ async function main() {
     WHERE "lockedAt" IS NOT NULL
       AND ("lockedTenthPlaceDriverId" IS NULL
         OR "lockedWinnerDriverId" IS NULL
-        OR "lockedDnfDriverId" IS NULL)
+        OR "lockedDnfDriverId" IS NULL
+        OR ("tenthPlaceSeatKey" IS NOT NULL AND "lockedTenthPlaceSeatKey" IS NULL)
+        OR ("winnerSeatKey" IS NOT NULL AND "lockedWinnerSeatKey" IS NULL)
+        OR ("dnfSeatKey" IS NOT NULL AND "lockedDnfSeatKey" IS NULL))
   `
 
   console.log(`Backfilled ${Number(updated)} row(s).`)
@@ -52,7 +58,10 @@ async function main() {
     WHERE "lockedAt" IS NOT NULL
       AND ("lockedTenthPlaceDriverId" IS NULL
         OR "lockedWinnerDriverId" IS NULL
-        OR "lockedDnfDriverId" IS NULL)
+        OR "lockedDnfDriverId" IS NULL
+        OR ("tenthPlaceSeatKey" IS NOT NULL AND "lockedTenthPlaceSeatKey" IS NULL)
+        OR ("winnerSeatKey" IS NOT NULL AND "lockedWinnerSeatKey" IS NULL)
+        OR ("dnfSeatKey" IS NOT NULL AND "lockedDnfSeatKey" IS NULL))
   `
   const remaining = Number(drift[0]?.count ?? 0)
   if (remaining > 0) {


### PR DESCRIPTION
Closes #350

## Summary
- Include live-seat-present plus locked-seat-missing gaps in the locked snapshot backfill target predicate.
- Apply the same seat-key gap checks to update and verification predicates.
- Extend static backfill coverage to assert driver and seat snapshot guards across all query blocks.

## Test Plan
- [x] `node --test scripts/backfill-locked-snapshots.test.mjs`
- [x] `npm run test:scripts:static`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `git diff --check`

## Review
- [x] Red test failed first on the missing locked seat-key predicate.
- [x] Subagent review: spec PASS, quality APPROVED, no findings.

— gib
