### PR TITLE
Cache public race APIs and cut avoidable Auth.js work

### DIFF
--- a/ai/docs/worklog.md
+++ b/ai/docs/worklog.md
@@ -40,6 +40,15 @@ Do NOT turn this into a giant diary.
 - should update architecture?: no — cache/invalidation details can land when #361 merges
 - should update decisions?: no
 
+### 2026-07-24 18:21 — Public race API cache headers
+- by: Codex
+- summary: Added shared CDN cache headers, cache tags, and Server-Timing to public race list/detail GETs; bypassed Auth.js middleware before public race GETs; added public race cache tag revalidation after schedule/status/entry/qualifying/result cron mutations.
+- files touched: `src/app/api/races`, `src/lib/api/public-race-cache.ts`, `src/middleware.ts`, `src/app/api/cron/*`, route source tests
+- verification: targeted race/cron source tests; `npm run test:routes`; `npx tsc --noEmit`; `npm run lint`; `npm run build`
+- open questions: Production CDN hit-rate/TTFB targets still need deployment telemetry; `/api/users/me` read consolidation was deferred.
+- should update architecture?: no
+- should update decisions?: no
+
 ### 2026-07-15 — Browser product UI retired behind the App Store landing
 - by: Codex
 - summary: Removed the retired browser route groups, component/provider/error-reporting tree, shadcn scaffold config, UI utility, and 12 browser-only direct packages. Preserved the complete API/Auth.js/scoring/cron/database surface, client-error intake/sanitizer, and driver/team asset contracts used by iOS.

--- a/src/app/api/cron/ingest-results/route.ts
+++ b/src/app/api/cron/ingest-results/route.ts
@@ -17,6 +17,7 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { validateCronSecret } from '@/lib/api/cron-auth'
+import { revalidatePublicRaceCache } from '@/lib/api/public-race-cache'
 import { db } from '@/lib/db/client'
 import { ingestResultsForRace, findRacesNeedingIngestion } from '@/lib/services/ingestion.service'
 import { computeAndStoreScoresForRace } from '@/lib/services/scoring.service'
@@ -85,6 +86,7 @@ export async function POST(req: NextRequest) {
     qualified: number
     error?: string
   }> = []
+  const mutatedRaceIds = new Set<string>()
 
   for (const raceId of targetRaceIds) {
     const raceStartedAt = Date.now()
@@ -172,6 +174,9 @@ export async function POST(req: NextRequest) {
         scored: outcome.scored,
         qualified: outcome.qualified,
       })
+      if (outcome.ingested > 0 || outcome.scored > 0 || outcome.qualified > 0) {
+        mutatedRaceIds.add(raceId)
+      }
       console.log(
         `[f10:cron:ingest] OK raceId=${raceId} ingested=${outcome.ingested} scored=${outcome.scored} qualified=${outcome.qualified} (${Date.now() - raceStartedAt}ms)`,
       )
@@ -187,6 +192,10 @@ export async function POST(req: NextRequest) {
   console.log(
     `[f10:cron:ingest] done in ${Date.now() - startedAt}ms processed=${results.length} errors=${results.filter((r) => r.error).length}`,
   )
+
+  if (mutatedRaceIds.size > 0) {
+    revalidatePublicRaceCache(mutatedRaceIds)
+  }
 
   return NextResponse.json({ processed: results })
 }

--- a/src/app/api/cron/lock-picks/route.ts
+++ b/src/app/api/cron/lock-picks/route.ts
@@ -11,6 +11,7 @@
 import { NextResponse } from "next/server"
 import type { NextRequest } from "next/server"
 import { validateCronSecret } from "@/lib/api/cron-auth"
+import { revalidatePublicRaceCache } from "@/lib/api/public-race-cache"
 import { db } from "@/lib/db/client"
 import { lockPicksForRace } from "@/lib/services/lock.service"
 
@@ -52,6 +53,7 @@ export async function POST(req: NextRequest) {
 
   let lockedRaces = 0
   let totalPicksLocked = 0
+  const statusChangedRaceIds = new Set<string>()
 
   for (const race of racesToLock) {
     // Lock all unlocked pick sets for this race
@@ -64,10 +66,13 @@ export async function POST(req: NextRequest) {
         : undefined
 
     if (newStatus) {
-      await db.race.updateMany({
+      const result = await db.race.updateMany({
         where: { id: race.id, status: "UPCOMING" },
         data: { status: newStatus },
       })
+      if (result.count > 0) {
+        statusChangedRaceIds.add(race.id)
+      }
     }
 
     console.log(
@@ -75,6 +80,10 @@ export async function POST(req: NextRequest) {
     )
 
     lockedRaces++
+  }
+
+  if (statusChangedRaceIds.size > 0) {
+    revalidatePublicRaceCache(statusChangedRaceIds)
   }
 
   console.log(

--- a/src/app/api/cron/sync-entries/route.ts
+++ b/src/app/api/cron/sync-entries/route.ts
@@ -14,6 +14,7 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { validateCronSecret } from '@/lib/api/cron-auth'
+import { revalidatePublicRaceCache } from '@/lib/api/public-race-cache'
 import { db } from '@/lib/db/client'
 import { createF1Provider } from '@/lib/f1/adapter'
 import { getRaceEntryRefreshSkipReason } from '../entry-refresh-guard'
@@ -147,6 +148,7 @@ export async function POST(req: NextRequest) {
 
   // Rebuild RaceEntry rows for each refreshed race.
   let refreshed = 0
+  const refreshedRaceIds = new Set<string>()
   const skipped: Array<{ raceId: string; reason: string }> = []
 
   for (const { race, drivers } of sessionResults) {
@@ -174,6 +176,11 @@ export async function POST(req: NextRequest) {
     ])
 
     refreshed++
+    refreshedRaceIds.add(race.id)
+  }
+
+  if (refreshedRaceIds.size > 0) {
+    revalidatePublicRaceCache(refreshedRaceIds)
   }
 
   return NextResponse.json({ refreshed, skipped, total: upcomingRaces.length })

--- a/src/app/api/cron/sync-schedule/route.ts
+++ b/src/app/api/cron/sync-schedule/route.ts
@@ -9,6 +9,7 @@
 import { NextResponse } from "next/server"
 import type { NextRequest } from "next/server"
 import { validateCronSecret } from "@/lib/api/cron-auth"
+import { revalidatePublicRaceCache } from "@/lib/api/public-race-cache"
 import { db } from "@/lib/db/client"
 import { createF1Provider } from "@/lib/f1/adapter"
 import { fetchDriversForSessions } from "./driver-fetch"
@@ -134,6 +135,7 @@ export async function POST(req: NextRequest) {
 
   const raceIdBySessionKey = new Map<number, string>()
   const entryCountByRaceId = new Map<string, number>()
+  const mutatedRaceIds = new Set<string>()
   let synced = 0
   let hadRaceUpsertFailure = false
 
@@ -266,6 +268,7 @@ export async function POST(req: NextRequest) {
             where: { id: existing.id },
             data: { ...updatePayload, openf1SessionKey: session.sessionKey },
           })
+          mutatedRaceIds.add(raceId)
         }
       } else {
         const created = await db.race.create({
@@ -273,6 +276,7 @@ export async function POST(req: NextRequest) {
           select: { id: true },
         })
         raceId = created.id
+        mutatedRaceIds.add(raceId)
       }
       raceIdBySessionKey.set(session.sessionKey, raceId)
       entryCountByRaceId.set(raceId, existingEntryCount)
@@ -336,6 +340,7 @@ export async function POST(req: NextRequest) {
       })
       reconciled = result.count
       for (const o of orphans) {
+        mutatedRaceIds.add(o.id)
         console.log(
           `[f10:cron:sync-schedule] reconcile CANCELLED R${o.round} ${o.type} "${o.name}" (id=${o.id}) — no longer in OpenF1`,
         )
@@ -349,6 +354,7 @@ export async function POST(req: NextRequest) {
 
   // Skip the remaining steps if no driver data was fetched
   if (sessionDrivers.every((sd) => sd.drivers.length === 0)) {
+    revalidatePublicRaceCache(mutatedRaceIds)
     return NextResponse.json({ synced, reconciled, year, driversSkipped: true })
   }
 
@@ -470,6 +476,9 @@ export async function POST(req: NextRequest) {
   }
 
   const refreshedRaceIds = Array.from(new Set(raceEntries.map((entry) => entry.raceId)))
+  for (const raceId of refreshedRaceIds) {
+    mutatedRaceIds.add(raceId)
+  }
 
   if (raceEntries.length > 0) {
     await db.$transaction([
@@ -479,6 +488,8 @@ export async function POST(req: NextRequest) {
       db.raceEntry.createMany({ data: raceEntries, skipDuplicates: true }),
     ])
   }
+
+  revalidatePublicRaceCache(mutatedRaceIds)
 
   return NextResponse.json({ synced, reconciled, year, entryRefreshSkipped })
 }

--- a/src/app/api/races/[id]/route.ts
+++ b/src/app/api/races/[id]/route.ts
@@ -4,17 +4,44 @@ import { getQualifyingResults } from '@/lib/services/qualifying.service'
 import { getDriverSeasonStats } from '@/lib/services/driver-season-stats'
 import { db } from '@/lib/db/client'
 import { getResultScoreGuide } from '@/lib/scoring/formula'
+import {
+  publicRaceHeaders,
+  raceDetailCacheControl,
+  raceNotFoundCacheControl,
+  serverTiming,
+} from '@/lib/api/public-race-cache'
 
 // No auth required — race details are public
 export async function GET(
   _request: Request,
   { params }: { params: { id: string } }
 ) {
+  const startedAt = Date.now()
+  const raceStartedAt = Date.now()
   const race = await getRaceById(params.id)
+  const raceDurationMs = Date.now() - raceStartedAt
+
   if (!race) {
-    return NextResponse.json({ error: 'Race not found' }, { status: 404 })
+    return NextResponse.json(
+      { error: 'Race not found' },
+      {
+        status: 404,
+        headers: publicRaceHeaders({
+          cacheControl: raceNotFoundCacheControl(),
+          raceId: params.id,
+          serverTiming: serverTiming([
+            { name: 'auth', durationMs: 0, description: 'public-bypass' },
+            { name: 'cache', durationMs: 0, description: 'shared' },
+            { name: 'db', durationMs: raceDurationMs },
+            { name: 'serialize', durationMs: 0 },
+            { name: 'total', durationMs: Date.now() - startedAt },
+          ]),
+        }),
+      },
+    )
   }
 
+  const relatedStartedAt = Date.now()
   const [entrants, seasonStats, resultRows, qualifyingResults] =
     await Promise.all([
       getRaceEntrants(params.id),
@@ -37,7 +64,9 @@ export async function GET(
         : Promise.resolve([]),
       (async () => await getQualifyingResults(params.id))(),
     ])
+  const relatedDurationMs = Date.now() - relatedStartedAt
 
+  const serializeStartedAt = Date.now()
   const enrichedEntrants = entrants.map((entrant) => {
     const stats = seasonStats.get(entrant.id)
     return {
@@ -51,18 +80,35 @@ export async function GET(
     ...result,
     scoreGuide: getResultScoreGuide(result, race.type),
   }))
+  const serializeDurationMs = Date.now() - serializeStartedAt
 
-  return NextResponse.json({
-    race: {
-      ...race,
-      scheduledStartUtc: race.scheduledStartUtc.toISOString(),
-      lockCutoffUtc: race.lockCutoffUtc.toISOString(),
-      qualifyingStartUtc: race.qualifyingStartUtc
-        ? race.qualifyingStartUtc.toISOString()
-        : null,
+  return NextResponse.json(
+    {
+      race: {
+        ...race,
+        scheduledStartUtc: race.scheduledStartUtc.toISOString(),
+        lockCutoffUtc: race.lockCutoffUtc.toISOString(),
+        qualifyingStartUtc: race.qualifyingStartUtc
+          ? race.qualifyingStartUtc.toISOString()
+          : null,
+      },
+      entrants: enrichedEntrants,
+      results,
+      qualifyingResults,
     },
-    entrants: enrichedEntrants,
-    results,
-    qualifyingResults,
-  })
+    {
+      headers: publicRaceHeaders({
+        cacheControl: raceDetailCacheControl(race.status),
+        raceId: params.id,
+        serverTiming: serverTiming([
+          { name: 'auth', durationMs: 0, description: 'public-bypass' },
+          { name: 'cache', durationMs: 0, description: 'shared' },
+          { name: 'db.race', durationMs: raceDurationMs },
+          { name: 'db.related', durationMs: relatedDurationMs },
+          { name: 'serialize', durationMs: serializeDurationMs },
+          { name: 'total', durationMs: Date.now() - startedAt },
+        ]),
+      }),
+    },
+  )
 }

--- a/src/app/api/races/route-source.test.mjs
+++ b/src/app/api/races/route-source.test.mjs
@@ -2,20 +2,85 @@ import test from "node:test"
 import assert from "node:assert/strict"
 import { readFile } from "node:fs/promises"
 
-const source = await readFile(new URL("./[id]/route.ts", import.meta.url), "utf8")
+const listSource = await readFile(new URL("./route.ts", import.meta.url), "utf8")
+const detailSource = await readFile(new URL("./[id]/route.ts", import.meta.url), "utf8")
+const cacheSource = await readFile(
+  new URL("../../../lib/api/public-race-cache.ts", import.meta.url),
+  "utf8",
+)
+const middlewareSource = await readFile(
+  new URL("../../../middleware.ts", import.meta.url),
+  "utf8",
+)
+const syncScheduleSource = await readFile(
+  new URL("../cron/sync-schedule/route.ts", import.meta.url),
+  "utf8",
+)
+const syncEntriesSource = await readFile(
+  new URL("../cron/sync-entries/route.ts", import.meta.url),
+  "utf8",
+)
+const ingestResultsSource = await readFile(
+  new URL("../cron/ingest-results/route.ts", import.meta.url),
+  "utf8",
+)
+const lockPicksSource = await readFile(
+  new URL("../cron/lock-picks/route.ts", import.meta.url),
+  "utf8",
+)
 
 test("race detail API lets qualifying result lookup failures surface", () => {
-  assert.match(source, /await getQualifyingResults\(params\.id\)/)
-  assert.doesNotMatch(source, /getQualifyingResults\(params\.id\)\.catch\(\(\) => \[\]\)/)
+  assert.match(detailSource, /await getQualifyingResults\(params\.id\)/)
+  assert.doesNotMatch(detailSource, /getQualifyingResults\(params\.id\)\.catch\(\(\) => \[\]\)/)
 })
 
 test("race detail API enriches entrants with season form without serial data waterfalls", () => {
-  assert.match(source, /import \{ getDriverSeasonStats \}/)
+  assert.match(detailSource, /import \{ getDriverSeasonStats \}/)
   assert.match(
-    source,
+    detailSource,
     /await Promise\.all\(\[\s*getRaceEntrants\(params\.id\),\s*getDriverSeasonStats\(\{/,
   )
-  assert.match(source, /seasonAverageFinish:/)
-  assert.match(source, /seasonDnfCount:/)
-  assert.match(source, /entrants:\s*enrichedEntrants/)
+  assert.match(detailSource, /seasonAverageFinish:/)
+  assert.match(detailSource, /seasonDnfCount:/)
+  assert.match(detailSource, /entrants:\s*enrichedEntrants/)
+})
+
+test("public race list and detail responses use shared cache and timing headers", () => {
+  assert.doesNotMatch(listSource, /force-dynamic/)
+  assert.match(listSource, /raceListCacheControl\(\)/)
+  assert.match(listSource, /publicRaceHeaders\(\{/)
+  assert.match(listSource, /Server-Timing|serverTiming/)
+
+  assert.match(detailSource, /raceDetailCacheControl\(race\.status\)/)
+  assert.match(detailSource, /raceNotFoundCacheControl\(\)/)
+  assert.match(detailSource, /publicRaceHeaders\(\{/)
+  assert.match(detailSource, /Server-Timing|serverTiming/)
+})
+
+test("public race cache TTLs are status appropriate", () => {
+  assert.match(cacheSource, /raceListCacheControl\(\)[\s\S]*s-maxage=60/)
+  assert.match(cacheSource, /case "COMPLETED":[\s\S]*case "CANCELLED":[\s\S]*s-maxage=3600/)
+  assert.match(cacheSource, /case "LIVE":[\s\S]*s-maxage=15/)
+  assert.match(cacheSource, /case "UPCOMING":[\s\S]*s-maxage=60/)
+})
+
+test("middleware bypasses Auth.js before public race GETs can set cookies", () => {
+  assert.match(middlewareSource, /function isPublicRaceApiGet/)
+  assert.match(
+    middlewareSource,
+    /if \(isPublicRaceApiGet\(pathname, req\.method\)\) \{\s*return NextResponse\.next\(\);\s*\}\s*return authMiddleware/,
+  )
+})
+
+test("race-data cron mutations revalidate public race cache tags", () => {
+  for (const source of [
+    syncScheduleSource,
+    syncEntriesSource,
+    ingestResultsSource,
+    lockPicksSource,
+  ]) {
+    assert.match(source, /revalidatePublicRaceCache/)
+  }
+  assert.match(cacheSource, /revalidateTag\(PUBLIC_RACES_TAG\)/)
+  assert.match(cacheSource, /revalidateTag\(publicRaceTag\(raceId\)\)/)
 })

--- a/src/app/api/races/route.ts
+++ b/src/app/api/races/route.ts
@@ -1,18 +1,46 @@
 import { NextResponse } from 'next/server'
+import { headers } from 'next/headers'
 import { getActiveSeason, getRacesForSeason } from '@/lib/services/race.service'
-
-export const dynamic = 'force-dynamic'
+import {
+  publicRaceHeaders,
+  raceListCacheControl,
+  serverTiming,
+} from '@/lib/api/public-race-cache'
 
 // No auth required — race schedule is public
 export async function GET() {
+  // DB-backed route: evaluate at request time, then let CDN cache via headers.
+  headers()
+
+  const startedAt = Date.now()
+  const dbStartedAt = Date.now()
   const season = await getActiveSeason()
+  let dbDurationMs = Date.now() - dbStartedAt
+
   if (!season) {
-    return NextResponse.json({ races: [], season: null })
+    return NextResponse.json(
+      { races: [], season: null },
+      {
+        headers: publicRaceHeaders({
+          cacheControl: raceListCacheControl(),
+          serverTiming: serverTiming([
+            { name: 'auth', durationMs: 0, description: 'public-bypass' },
+            { name: 'cache', durationMs: 0, description: 'shared' },
+            { name: 'db', durationMs: dbDurationMs },
+            { name: 'serialize', durationMs: 0 },
+            { name: 'total', durationMs: Date.now() - startedAt },
+          ]),
+        }),
+      },
+    )
   }
 
+  const racesStartedAt = Date.now()
   const races = await getRacesForSeason(season.id)
+  dbDurationMs += Date.now() - racesStartedAt
 
   // Serialize dates for JSON
+  const serializeStartedAt = Date.now()
   const serialized = races.map((r) => ({
     ...r,
     scheduledStartUtc: r.scheduledStartUtc.toISOString(),
@@ -21,6 +49,21 @@ export async function GET() {
       ? r.qualifyingStartUtc.toISOString()
       : null,
   }))
+  const serializeDurationMs = Date.now() - serializeStartedAt
 
-  return NextResponse.json({ races: serialized, season })
+  return NextResponse.json(
+    { races: serialized, season },
+    {
+      headers: publicRaceHeaders({
+        cacheControl: raceListCacheControl(),
+        serverTiming: serverTiming([
+          { name: 'auth', durationMs: 0, description: 'public-bypass' },
+          { name: 'cache', durationMs: 0, description: 'shared' },
+          { name: 'db', durationMs: dbDurationMs },
+          { name: 'serialize', durationMs: serializeDurationMs },
+          { name: 'total', durationMs: Date.now() - startedAt },
+        ]),
+      }),
+    },
+  )
 }

--- a/src/app/api/users/me/get-handler.js
+++ b/src/app/api/users/me/get-handler.js
@@ -1,37 +1,18 @@
-export async function handleUsersMeGet(
-  req,
-  {
-    auth,
-    mobileAuth,
-    db,
-  },
-) {
-  const session = (await auth()) ?? (await mobileAuth(req))
-  if (!session?.user?.id) {
-    return Response.json({ error: "Unauthorized" }, { status: 401 })
-  }
+export const USERS_ME_PROFILE_SELECT = {
+  id: true,
+  name: true,
+  email: true,
+  image: true,
+  publicUsername: true,
+  usernameSet: true,
+  usernameChangeUsed: true,
+  favoriteTeamSlug: true,
+  tutorialDismissedAt: true,
+  createdAt: true,
+}
 
-  const user = await db.user.findUnique({
-    where: { id: session.user.id },
-    select: {
-      id: true,
-      name: true,
-      email: true,
-      image: true,
-      publicUsername: true,
-      usernameSet: true,
-      usernameChangeUsed: true,
-      favoriteTeamSlug: true,
-      tutorialDismissedAt: true,
-      createdAt: true,
-    },
-  })
-
-  if (!user) {
-    return Response.json({ error: "User not found" }, { status: 404 })
-  }
-
-  return Response.json({
+function serializeUser(user) {
+  return {
     id: user.id,
     name: user.name,
     email: user.email,
@@ -42,5 +23,41 @@ export async function handleUsersMeGet(
     favoriteTeamSlug: user.favoriteTeamSlug,
     tutorialDismissedAt: user.tutorialDismissedAt?.toISOString() ?? null,
     createdAt: user.createdAt.toISOString(),
-  })
+  }
+}
+
+export async function handleUsersMeGet(
+  req,
+  {
+    auth,
+    mobileAuth,
+    db,
+  },
+) {
+  let session = await auth()
+  let hydratedUser = null
+
+  if (!session) {
+    session = await mobileAuth(req, { userSelect: USERS_ME_PROFILE_SELECT })
+    if (session && session.databaseUser?.id === session.user?.id) {
+      hydratedUser = session.databaseUser
+    }
+  }
+
+  if (!session?.user?.id) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const user =
+    hydratedUser ??
+    (await db.user.findUnique({
+      where: { id: session.user.id },
+      select: USERS_ME_PROFILE_SELECT,
+    }))
+
+  if (!user) {
+    return Response.json({ error: "User not found" }, { status: 404 })
+  }
+
+  return Response.json(serializeUser(user))
 }

--- a/src/app/api/users/me/get-handler.test.mjs
+++ b/src/app/api/users/me/get-handler.test.mjs
@@ -1,7 +1,7 @@
 import test from "node:test"
 import assert from "node:assert/strict"
 
-import { handleUsersMeGet } from "./get-handler.js"
+import { handleUsersMeGet, USERS_ME_PROFILE_SELECT } from "./get-handler.js"
 
 function request() {
   return new Request("http://localhost/api/users/me")
@@ -59,10 +59,14 @@ test("GET /api/users/me returns 401 without cookie or bearer auth", async () => 
 
 test("GET /api/users/me falls back to bearer auth and returns 404 for a missing user", async () => {
   const findCalls = []
+  const mobileAuthCalls = []
   const response = await handleUsersMeGet(
     request(),
     dependencies({
-      mobileAuth: async () => ({ user: { id: "mobile-user" } }),
+      mobileAuth: async (_request, options) => {
+        mobileAuthCalls.push(options)
+        return { user: { id: "mobile-user" } }
+      },
       db: {
         user: {
           findUnique: async (query) => {
@@ -75,8 +79,65 @@ test("GET /api/users/me falls back to bearer auth and returns 404 for a missing 
   )
 
   assert.equal(response.status, 404)
+  assert.deepEqual(mobileAuthCalls, [{ userSelect: USERS_ME_PROFILE_SELECT }])
   assert.equal(findCalls[0].where.id, "mobile-user")
   assert.deepEqual(await response.json(), { error: "User not found" })
+})
+
+test("GET /api/users/me reuses mobile auth profile from the revocation read", async () => {
+  const dbCalls = []
+  const mobileAuthCalls = []
+  const response = await handleUsersMeGet(
+    request(),
+    dependencies({
+      mobileAuth: async (_request, options) => {
+        mobileAuthCalls.push(options)
+        return {
+          user: { id: "mobile-user" },
+          databaseUser: user({ id: "mobile-user", publicUsername: "mobile" }),
+        }
+      },
+      db: {
+        user: {
+          findUnique: async (query) => {
+            dbCalls.push(query)
+            return null
+          },
+        },
+      },
+    }),
+  )
+
+  assert.equal(response.status, 200)
+  assert.deepEqual(mobileAuthCalls, [{ userSelect: USERS_ME_PROFILE_SELECT }])
+  assert.deepEqual(dbCalls, [])
+  assert.equal((await response.json()).publicUsername, "mobile")
+})
+
+test("GET /api/users/me ignores a mismatched hydrated mobile auth profile", async () => {
+  const findCalls = []
+  const response = await handleUsersMeGet(
+    request(),
+    dependencies({
+      mobileAuth: async () => ({
+        user: { id: "mobile-user" },
+        databaseUser: user({ id: "other-user", publicUsername: "other" }),
+      }),
+      db: {
+        user: {
+          findUnique: async (query) => {
+            findCalls.push(query)
+            return user({ id: "mobile-user", publicUsername: "mobile" })
+          },
+        },
+      },
+    }),
+  )
+
+  assert.equal(response.status, 200)
+  assert.equal(findCalls.length, 1)
+  assert.equal(findCalls[0].where.id, "mobile-user")
+  assert.equal((await response.json()).publicUsername, "mobile")
 })
 
 test("GET /api/users/me serializes nullable and populated profile dates", async () => {

--- a/src/lib/api/public-race-cache.ts
+++ b/src/lib/api/public-race-cache.ts
@@ -1,0 +1,72 @@
+import { revalidateTag } from "next/cache"
+import type { RaceSummary } from "@/types/domain"
+
+export const PUBLIC_RACES_TAG = "public-races"
+
+export function publicRaceTag(raceId: string): string {
+  return `public-race:${raceId}`
+}
+
+export function raceListCacheControl(): string {
+  return "public, s-maxage=60, stale-while-revalidate=300"
+}
+
+export function raceDetailCacheControl(status: RaceSummary["status"]): string {
+  switch (status) {
+    case "COMPLETED":
+    case "CANCELLED":
+      return "public, s-maxage=3600, stale-while-revalidate=86400"
+    case "LIVE":
+      return "public, s-maxage=15, stale-while-revalidate=30"
+    case "UPCOMING":
+      return "public, s-maxage=60, stale-while-revalidate=300"
+  }
+
+  return "public, s-maxage=60, stale-while-revalidate=300"
+}
+
+export function raceNotFoundCacheControl(): string {
+  return "public, s-maxage=30, stale-while-revalidate=60"
+}
+
+export function publicRaceCacheTagHeader(raceId?: string): string {
+  return raceId ? `${PUBLIC_RACES_TAG}, ${publicRaceTag(raceId)}` : PUBLIC_RACES_TAG
+}
+
+export function serverTiming(
+  entries: Array<{ name: string; durationMs?: number; description?: string }>,
+): string {
+  return entries
+    .map(({ name, durationMs, description }) => {
+      const parts = [name]
+      if (description) parts.push(`desc="${description}"`)
+      if (durationMs !== undefined) {
+        parts.push(`dur=${Math.max(0, durationMs).toFixed(1)}`)
+      }
+      return parts.join(";")
+    })
+    .join(", ")
+}
+
+export function publicRaceHeaders({
+  cacheControl,
+  raceId,
+  serverTiming: timing,
+}: {
+  cacheControl: string
+  raceId?: string
+  serverTiming: string
+}): HeadersInit {
+  return {
+    "Cache-Control": cacheControl,
+    "Cache-Tag": publicRaceCacheTagHeader(raceId),
+    "Server-Timing": timing,
+  }
+}
+
+export function revalidatePublicRaceCache(raceIds: Iterable<string> = []): void {
+  revalidateTag(PUBLIC_RACES_TAG)
+  for (const raceId of Array.from(new Set(raceIds))) {
+    revalidateTag(publicRaceTag(raceId))
+  }
+}

--- a/src/lib/auth/mobileAuth.test.mjs
+++ b/src/lib/auth/mobileAuth.test.mjs
@@ -144,3 +144,73 @@ test("mobileAuth accepts valid exp-bearing mobile tokens", async () => {
     assert.equal(session?.expires, new Date(exp * 1000).toISOString())
   })
 })
+
+test("mobileAuth can hydrate route-selected user fields during revocation lookup", async () => {
+  await withAuthSecret(async () => {
+    let query
+    const createdAt = new Date("2026-06-01T12:00:00.000Z")
+    mockDb.user.findUnique = async (receivedQuery) => {
+      query = receivedQuery
+      return {
+        id: "user-1",
+        publicUsername: "driverone",
+        createdAt,
+        sessionValidAfter: null,
+      }
+    }
+
+    const exp = Math.floor(Date.now() / 1000) + 60 * 60
+    const token = await new SignJWT({ id: "user-1" })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt()
+      .setExpirationTime(exp)
+      .sign(signingKey())
+
+    const session = await mobileAuth(bearerRequest(token), {
+      userSelect: { id: true, publicUsername: true, createdAt: true },
+    })
+
+    assert.deepEqual(query, {
+      where: { id: "user-1" },
+      select: {
+        id: true,
+        publicUsername: true,
+        createdAt: true,
+        sessionValidAfter: true,
+      },
+    })
+    assert.equal(session?.databaseUser?.id, "user-1")
+    assert.equal(session?.databaseUser?.publicUsername, "driverone")
+    assert.equal(session?.databaseUser?.createdAt, createdAt)
+  })
+})
+
+test("mobileAuth still rejects hydrated tokens older than the revocation cutoff", async () => {
+  await withAuthSecret(async () => {
+    let query
+    const issuedAt = Math.floor(Date.now() / 1000) - 120
+    mockDb.user.findUnique = async (receivedQuery) => {
+      query = receivedQuery
+      return {
+        id: "user-1",
+        sessionValidAfter: new Date((issuedAt + 60) * 1000),
+      }
+    }
+
+    const token = await new SignJWT({ id: "user-1" })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt(issuedAt)
+      .setExpirationTime(issuedAt + 60 * 60)
+      .sign(signingKey())
+
+    const session = await mobileAuth(bearerRequest(token), {
+      userSelect: { id: true },
+    })
+
+    assert.deepEqual(query, {
+      where: { id: "user-1" },
+      select: { id: true, sessionValidAfter: true },
+    })
+    assert.equal(session, null)
+  })
+})

--- a/src/lib/auth/mobileAuth.ts
+++ b/src/lib/auth/mobileAuth.ts
@@ -15,14 +15,32 @@
 
 import { jwtVerify } from 'jose'
 import { db } from '@/lib/db/client'
+import type { Prisma } from '@prisma/client'
 import type { Session } from 'next-auth'
+
+type MobileAuthOptions = {
+  /**
+   * Optional fields to hydrate from the same user read used for revocation.
+   * Routes must still fall back to their normal DB read if this is absent.
+   */
+  userSelect?: Prisma.UserSelect
+}
+
+type MobileAuthDatabaseUser = { sessionValidAfter: Date | null } & Record<string, unknown>
+
+export type MobileAuthSession = Session & {
+  databaseUser?: MobileAuthDatabaseUser
+}
 
 /** Derive a stable signing key from AUTH_SECRET for mobile JWTs. */
 export function mobileSigningKey(): Uint8Array {
   return Buffer.from(process.env.AUTH_SECRET!, 'utf-8')
 }
 
-export async function mobileAuth(req: Request): Promise<Session | null> {
+export async function mobileAuth(
+  req: Request,
+  options: MobileAuthOptions = {},
+): Promise<MobileAuthSession | null> {
   const authHeader = req.headers.get('authorization')
   if (!authHeader?.startsWith('Bearer ')) return null
 
@@ -54,28 +72,31 @@ export async function mobileAuth(req: Request): Promise<Session | null> {
   // ~hundreds of ms before sessionValidAfter once iat is rounded down.
   // Compare in whole seconds so a brand-new account is never rejected by
   // its own freshly-issued token.
+  let databaseUser: MobileAuthDatabaseUser | null = null
   try {
     const user = await db.user.findUnique({
       where: { id: userId },
-      select: { sessionValidAfter: true },
+      select: { ...(options.userSelect ?? {}), sessionValidAfter: true },
     })
-    if (!user) {
+    const userWithRevocation = user as MobileAuthDatabaseUser | null
+    if (!userWithRevocation) {
       return null
     }
 
     if (
-      user.sessionValidAfter &&
+      userWithRevocation.sessionValidAfter &&
       sessionIssuedAtMs !== null &&
       sessionIssuedAtMs <
-        Math.floor(user.sessionValidAfter.getTime() / 1000) * 1000
+        Math.floor(userWithRevocation.sessionValidAfter.getTime() / 1000) * 1000
     ) {
       return null // Token has been revoked via POST /api/auth/revoke-session
     }
+    databaseUser = userWithRevocation
   } catch {
     // DB unavailable — skip revocation check, proceed with token claims
   }
 
-  return {
+  const session: MobileAuthSession = {
     user: {
       id: userId,
       name: (payload.name as string | null) ?? null,
@@ -86,5 +107,11 @@ export async function mobileAuth(req: Request): Promise<Session | null> {
       sessionIssuedAtMs,
     },
     expires: new Date(payload.exp * 1000).toISOString(),
-  } as Session
+  } as MobileAuthSession
+
+  if (databaseUser && options.userSelect) {
+    session.databaseUser = databaseUser
+  }
+
+  return session
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,6 +12,13 @@ const { auth } = NextAuth(authConfig);
 // when `auth()` is used as a middleware wrapper.
 type NextAuthRequest = NextRequest & { auth: Session | null };
 
+function isPublicRaceApiGet(pathname: string, method: string): boolean {
+  return (
+    method === "GET" &&
+    (pathname === "/api/races" || pathname.startsWith("/api/races/"))
+  );
+}
+
 function isPublicApiRoute(pathname: string, method: string): boolean {
   if (pathname === "/api/client-errors") {
     return method === "POST";
@@ -36,7 +43,7 @@ function isPublicApiRoute(pathname: string, method: string): boolean {
   );
 }
 
-export default auth((req: NextAuthRequest) => {
+const authMiddleware = auth((req: NextAuthRequest) => {
   const { nextUrl, auth: session } = req;
   const pathname = nextUrl.pathname;
 
@@ -79,6 +86,19 @@ export default auth((req: NextAuthRequest) => {
   // ── 4. Authenticated API request — allow the request ──────────────────
   return NextResponse.next();
 });
+
+export default function middleware(...args: Parameters<typeof authMiddleware>) {
+  const req = args[0] as NextRequest;
+  const pathname = req.nextUrl.pathname;
+
+  // Public race GETs are CDN-cacheable and must not invoke Auth.js, which may
+  // refresh session cookies even though these responses are completely public.
+  if (isPublicRaceApiGet(pathname, req.method)) {
+    return NextResponse.next();
+  }
+
+  return authMiddleware(...args);
+}
 
 export const config = {
   // Auth.js handles /api/auth/* directly through its route handler.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Refs #361 — implements the highest-value server-side TTFB wins.

## Changes
- Shared Cache-Control on `/api/races` and status-aware caching on `/api/races/[id]`
- Server-Timing phases on race routes
- Public race GETs bypass Auth.js middleware before session work (no avoidable cookies)
- Cache tags + `revalidateTag` after schedule/status/entry/qualifying/result mutations
- Consolidated mobile `/api/users/me` so hydrated mobile auth can reuse the revocation/profile user read
- Contract tests for headers, bypass, TTLs, parallelization, invalidation, and me-route consolidation

## Deferred (needs production measurement after merge/deploy)
- `/api/races` CDN-hit TTFB p95 ≤ 250 ms
- `/api/races` warm-origin TTFB p95 ≤ 750 ms
- Public cache hit rate outside live windows ≥ 90%

## Test plan
- [x] `npm run test:routes` / `test:auth`
- [x] `npx tsc --noEmit` / `npm run lint` / `npm run build`

— gib

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99f35b6a-f0e9-4311-b21c-c3ef948318f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99f35b6a-f0e9-4311-b21c-c3ef948318f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

