### PR TITLE
Guard sync-schedule against partial OpenF1 entry lists

### DIFF
--- a/src/app/api/cron/entry-refresh-guard.ts
+++ b/src/app/api/cron/entry-refresh-guard.ts
@@ -1,0 +1,19 @@
+export const MIN_VALID_ENTRY_COUNT = 10
+
+export function getRaceEntryRefreshSkipReason({
+  existingCount,
+  nextCount,
+}: {
+  existingCount: number
+  nextCount: number
+}): string | null {
+  if (nextCount < MIN_VALID_ENTRY_COUNT) {
+    return `too-few-entries:${nextCount}`
+  }
+
+  if (existingCount > 0 && nextCount < existingCount) {
+    return `entry-count-regression:${existingCount}->${nextCount}`
+  }
+
+  return null
+}

--- a/src/app/api/cron/sync-entries/route.test.mjs
+++ b/src/app/api/cron/sync-entries/route.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict"
 import { readFile } from "node:fs/promises"
 
 const route = await readFile(new URL("./route.ts", import.meta.url), "utf8")
+const entryGuard = await readFile(new URL("../entry-refresh-guard.ts", import.meta.url), "utf8")
 
 test("sync-entries only selects race statuses whose grids can still change", () => {
   assert.match(route, /status:\s*\{\s*in:\s*\[\s*'UPCOMING',\s*'LIVE'\s*\]/s)
@@ -10,25 +11,27 @@ test("sync-entries only selects race statuses whose grids can still change", () 
 })
 
 test("sync-entries skips partial provider entry sets before rewriting grids", () => {
-  assert.match(route, /const MIN_VALID_ENTRY_COUNT = 10/)
+  assert.match(route, /getRaceEntryRefreshSkipReason/)
+  assert.match(entryGuard, /export const MIN_VALID_ENTRY_COUNT = 10/)
+  assert.match(entryGuard, /nextCount < MIN_VALID_ENTRY_COUNT/)
+  assert.match(entryGuard, /`too-few-entries:\$\{nextCount\}`/)
+  assert.match(entryGuard, /existingCount > 0 && nextCount < existingCount/)
+  assert.match(entryGuard, /`entry-count-regression:\$\{existingCount\}->\$\{nextCount\}`/)
 
   const rebuildBlock = route.match(/for \(const \{ race, drivers \} of sessionResults\) \{[\s\S]*?\n  \}/)?.[0]
   assert.ok(rebuildBlock, "race entry rebuild loop should exist")
 
-  const tooFewIndex = rebuildBlock.indexOf("entries.length < MIN_VALID_ENTRY_COUNT")
-  const tooFewSkipIndex = rebuildBlock.indexOf("reason: `too-few-entries:${entries.length}`")
-  const existingCountIndex = rebuildBlock.indexOf("const existingCount = race._count.entries")
-  const regressionGuardIndex = rebuildBlock.indexOf("existingCount > 0 && entries.length < existingCount")
-  const regressionSkipIndex = rebuildBlock.indexOf("reason: `entry-count-regression:${existingCount}->${entries.length}`")
+  const guardIndex = rebuildBlock.indexOf("const skipReason = getRaceEntryRefreshSkipReason")
+  const existingCountIndex = rebuildBlock.indexOf("existingCount: race._count.entries")
+  const nextCountIndex = rebuildBlock.indexOf("nextCount: entries.length")
+  const skipIndex = rebuildBlock.indexOf("skipped.push({ raceId: race.id, reason: skipReason })")
   const deleteIndex = rebuildBlock.indexOf("db.raceEntry.deleteMany")
 
-  assert.notEqual(tooFewIndex, -1, "suspiciously small provider results should be guarded")
-  assert.notEqual(tooFewSkipIndex, -1, "too-few provider results should be reported as skipped")
+  assert.notEqual(guardIndex, -1, "partial provider results should be guarded")
   assert.notEqual(existingCountIndex, -1, "existing grid size should be considered")
-  assert.notEqual(regressionGuardIndex, -1, "provider results that shrink an existing grid should be guarded")
-  assert.notEqual(regressionSkipIndex, -1, "entry count regressions should be reported as skipped")
+  assert.notEqual(nextCountIndex, -1, "candidate grid size should be considered")
+  assert.notEqual(skipIndex, -1, "guarded provider results should be reported as skipped")
   assert.notEqual(deleteIndex, -1, "route should still rewrite valid grids")
 
-  assert.ok(tooFewIndex < deleteIndex, "minimum-count guard should run before deleting entries")
-  assert.ok(regressionGuardIndex < deleteIndex, "count-regression guard should run before deleting entries")
+  assert.ok(guardIndex < deleteIndex, "entry guard should run before deleting entries")
 })

--- a/src/app/api/cron/sync-entries/route.ts
+++ b/src/app/api/cron/sync-entries/route.ts
@@ -16,8 +16,7 @@ import type { NextRequest } from 'next/server'
 import { validateCronSecret } from '@/lib/api/cron-auth'
 import { db } from '@/lib/db/client'
 import { createF1Provider } from '@/lib/f1/adapter'
-
-const MIN_VALID_ENTRY_COUNT = 10
+import { getRaceEntryRefreshSkipReason } from '../entry-refresh-guard'
 
 export async function POST(req: NextRequest) {
   if (!validateCronSecret(req)) {
@@ -160,16 +159,12 @@ export async function POST(req: NextRequest) {
       .map((d) => ({ raceId: race.id, driverId: driverIdByNumber.get(d.driverNumber) }))
       .filter((e): e is { raceId: string; driverId: string } => e.driverId !== undefined)
 
-    const existingCount = race._count.entries
-    if (entries.length < MIN_VALID_ENTRY_COUNT) {
-      skipped.push({ raceId: race.id, reason: `too-few-entries:${entries.length}` })
-      continue
-    }
-    if (existingCount > 0 && entries.length < existingCount) {
-      skipped.push({
-        raceId: race.id,
-        reason: `entry-count-regression:${existingCount}->${entries.length}`,
-      })
+    const skipReason = getRaceEntryRefreshSkipReason({
+      existingCount: race._count.entries,
+      nextCount: entries.length,
+    })
+    if (skipReason) {
+      skipped.push({ raceId: race.id, reason: skipReason })
       continue
     }
 

--- a/src/app/api/cron/sync-schedule/route.test.mjs
+++ b/src/app/api/cron/sync-schedule/route.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict"
 import { readFile } from "node:fs/promises"
 
 const route = await readFile(new URL("./route.ts", import.meta.url), "utf8")
+const entryGuard = await readFile(new URL("../entry-refresh-guard.ts", import.meta.url), "utf8")
 
 function seasonActivationBlock() {
   const start = route.indexOf("let season = await db.season.findFirst")
@@ -20,6 +21,16 @@ function upsertBlock() {
 
   assert.notEqual(start, -1, "expected existing-race lookup block")
   assert.notEqual(end, -1, "expected reconcile section after upsert block")
+
+  return route.slice(start, end)
+}
+
+function entryRebuildBlock() {
+  const start = route.indexOf("const raceEntries: { raceId: string; driverId: string }[] = []")
+  const end = route.indexOf("return NextResponse.json({ synced, reconciled, year", start)
+
+  assert.notEqual(start, -1, "expected race entry rebuild block")
+  assert.notEqual(end, -1, "expected response after race entry rebuild block")
 
   return route.slice(start, end)
 }
@@ -42,13 +53,42 @@ test("sync-schedule activates an existing inactive current-year season", () => {
 test("sync-schedule skips updates for completed existing races", () => {
   const block = upsertBlock()
 
-  assert.match(block, /select: \{ id: true, status: true \}/)
   assert.match(
     block,
-    /if \(existing\) \{\s*raceId = existing\.id\s*if \(existing\.status !== "COMPLETED"\) \{\s*await db\.race\.update\(/,
+    /select: \{ id: true, status: true, _count: \{ select: \{ entries: true \} \} \}/,
   )
   assert.match(
     block,
-    /raceIdBySessionKey\.set\(session\.sessionKey, raceId\)\s*synced\+\+/,
+    /if \(existing\) \{\s*raceId = existing\.id\s*existingEntryCount = existing\._count\.entries\s*if \(existing\.status !== "COMPLETED"\) \{\s*await db\.race\.update\(/,
   )
+  assert.match(
+    block,
+    /raceIdBySessionKey\.set\(session\.sessionKey, raceId\)\s*entryCountByRaceId\.set\(raceId, existingEntryCount\)\s*synced\+\+/,
+  )
+})
+
+test("sync-schedule skips partial provider entry sets before rewriting grids", () => {
+  assert.match(route, /getRaceEntryRefreshSkipReason/)
+  assert.match(entryGuard, /export const MIN_VALID_ENTRY_COUNT = 10/)
+  assert.match(entryGuard, /nextCount < MIN_VALID_ENTRY_COUNT/)
+  assert.match(entryGuard, /`too-few-entries:\$\{nextCount\}`/)
+  assert.match(entryGuard, /existingCount > 0 && nextCount < existingCount/)
+  assert.match(entryGuard, /`entry-count-regression:\$\{existingCount\}->\$\{nextCount\}`/)
+
+  const block = entryRebuildBlock()
+  const entriesIndex = block.indexOf("const entries = drivers")
+  const guardIndex = block.indexOf("const skipReason = getRaceEntryRefreshSkipReason")
+  const existingCountIndex = block.indexOf("existingCount: entryCountByRaceId.get(raceId) ?? 0")
+  const nextCountIndex = block.indexOf("nextCount: entries.length")
+  const skipIndex = block.indexOf("entryRefreshSkipped.push({ raceId, reason: skipReason })")
+  const deleteIndex = block.indexOf("db.raceEntry.deleteMany")
+
+  assert.notEqual(entriesIndex, -1, "route should build per-race candidate entries")
+  assert.notEqual(guardIndex, -1, "partial provider results should be guarded")
+  assert.notEqual(existingCountIndex, -1, "existing grid size should be considered")
+  assert.notEqual(nextCountIndex, -1, "candidate grid size should be considered")
+  assert.notEqual(skipIndex, -1, "guarded provider results should be reported as skipped")
+  assert.notEqual(deleteIndex, -1, "route should still rewrite valid grids")
+
+  assert.ok(guardIndex < deleteIndex, "entry guard should run before deleting entries")
 })

--- a/src/app/api/cron/sync-schedule/route.ts
+++ b/src/app/api/cron/sync-schedule/route.ts
@@ -12,6 +12,7 @@ import { validateCronSecret } from "@/lib/api/cron-auth"
 import { db } from "@/lib/db/client"
 import { createF1Provider } from "@/lib/f1/adapter"
 import { fetchDriversForSessions } from "./driver-fetch"
+import { getRaceEntryRefreshSkipReason } from "../entry-refresh-guard"
 
 // ─────────────────────────────────────────────────────────────────────────────
 // POST /api/cron/sync-schedule
@@ -132,6 +133,7 @@ export async function POST(req: NextRequest) {
   const allQualifyingSessions = sessions.filter((s) => s.type === "Qualifying")
 
   const raceIdBySessionKey = new Map<number, string>()
+  const entryCountByRaceId = new Map<string, number>()
   let synced = 0
   let hadRaceUpsertFailure = false
 
@@ -235,7 +237,7 @@ export async function POST(req: NextRequest) {
           openf1MeetingKey: session.meetingKey,
           type: raceType as "MAIN" | "SPRINT",
         },
-        select: { id: true, status: true },
+        select: { id: true, status: true, _count: { select: { entries: true } } },
       })
 
       if (!existing) {
@@ -250,13 +252,15 @@ export async function POST(req: NextRequest) {
               lte: new Date(start + windowMs),
             },
           },
-          select: { id: true, status: true },
+          select: { id: true, status: true, _count: { select: { entries: true } } },
         })
       }
 
       let raceId: string
+      let existingEntryCount = 0
       if (existing) {
         raceId = existing.id
+        existingEntryCount = existing._count.entries
         if (existing.status !== "COMPLETED") {
           await db.race.update({
             where: { id: existing.id },
@@ -271,6 +275,7 @@ export async function POST(req: NextRequest) {
         raceId = created.id
       }
       raceIdBySessionKey.set(session.sessionKey, raceId)
+      entryCountByRaceId.set(raceId, existingEntryCount)
       synced++
     } catch (err) {
       hadRaceUpsertFailure = true
@@ -438,26 +443,42 @@ export async function POST(req: NextRequest) {
       .map((s) => s.sessionKey),
   )
   const raceEntries: { raceId: string; driverId: string }[] = []
+  const entryRefreshSkipped: Array<{ raceId: string; reason: string }> = []
 
   for (const { session, drivers } of sessionDrivers) {
     if (!raceSessions.has(session.sessionKey)) continue
     const raceId = raceIdBySessionKey.get(session.sessionKey)
     if (!raceId) continue
-    for (const driver of drivers) {
-      const driverId = driverIdByNumber.get(driver.driverNumber)
-      if (!driverId) continue
-      raceEntries.push({ raceId, driverId })
+
+    const entries = drivers
+      .map((driver) => ({
+        raceId,
+        driverId: driverIdByNumber.get(driver.driverNumber),
+      }))
+      .filter((entry): entry is { raceId: string; driverId: string } => entry.driverId !== undefined)
+
+    const skipReason = getRaceEntryRefreshSkipReason({
+      existingCount: entryCountByRaceId.get(raceId) ?? 0,
+      nextCount: entries.length,
+    })
+    if (skipReason) {
+      entryRefreshSkipped.push({ raceId, reason: skipReason })
+      continue
     }
+
+    raceEntries.push(...entries)
   }
 
   const refreshedRaceIds = Array.from(new Set(raceEntries.map((entry) => entry.raceId)))
 
-  await db.$transaction([
-    db.raceEntry.deleteMany({
-      where: { raceId: { in: refreshedRaceIds } },
-    }),
-    db.raceEntry.createMany({ data: raceEntries, skipDuplicates: true }),
-  ])
+  if (raceEntries.length > 0) {
+    await db.$transaction([
+      db.raceEntry.deleteMany({
+        where: { raceId: { in: refreshedRaceIds } },
+      }),
+      db.raceEntry.createMany({ data: raceEntries, skipDuplicates: true }),
+    ])
+  }
 
-  return NextResponse.json({ synced, reconciled, year })
+  return NextResponse.json({ synced, reconciled, year, entryRefreshSkipped })
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Closes #376.

Applies the same partial-provider entry safeguards used by `sync-entries` to `sync-schedule`, via a shared helper.

This branch is rebased onto `cursor/fix-375-377-cron-provider-18f2` so it includes #375/#377 and avoids a `sync-schedule` merge conflict. Prefer merging #384 first, or merge this PR alone if #384 is still open (this branch already contains those commits).

## Changes
- Shared `MIN_VALID_ENTRY_COUNT` + regression skip helper
- `sync-schedule` skips wipe/rebuild when driver lists are too small or regress
- Completed-race immutability preserved
- Regression tests for both cron paths (+ season activation tests from #377)

## Test plan
- [x] `node --test` sync-schedule + sync-entries route tests
- [x] Rebase conflict resolved; both season-activation and entry-guard tests pass together

— gib

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99f35b6a-f0e9-4311-b21c-c3ef948318f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99f35b6a-f0e9-4311-b21c-c3ef948318f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

