### PR TITLE
Defer OpenF1 stints failures and reactivate current season

### DIFF
--- a/src/app/api/cron/sync-schedule/route.test.mjs
+++ b/src/app/api/cron/sync-schedule/route.test.mjs
@@ -4,6 +4,16 @@ import { readFile } from "node:fs/promises"
 
 const route = await readFile(new URL("./route.ts", import.meta.url), "utf8")
 
+function seasonActivationBlock() {
+  const start = route.indexOf("let season = await db.season.findFirst")
+  const end = route.indexOf("// ── 2. Fetch sessions + meetings", start)
+
+  assert.notEqual(start, -1, "expected season lookup block")
+  assert.notEqual(end, -1, "expected provider fetch section after season block")
+
+  return route.slice(start, end)
+}
+
 function upsertBlock() {
   const start = route.indexOf("let existing = await db.race.findFirst")
   const end = route.indexOf("// ── 6.5. Reconcile orphan races", start)
@@ -13,6 +23,21 @@ function upsertBlock() {
 
   return route.slice(start, end)
 }
+
+test("sync-schedule activates an existing inactive current-year season", () => {
+  const block = seasonActivationBlock()
+
+  assert.match(block, /select: \{ id: true, year: true, isActive: true \}/)
+  assert.match(block, /else if \(!season\.isActive\) \{/)
+  assert.match(
+    block,
+    /db\.season\.updateMany\(\{\s*where: \{ isActive: true, id: \{ not: season\.id \} \},\s*data: \{ isActive: false \},\s*\}\)/,
+  )
+  assert.match(
+    block,
+    /db\.season\.update\(\{\s*where: \{ id: season\.id \},\s*data: \{ isActive: true \},\s*select: \{ id: true, year: true, isActive: true \},\s*\}\)/,
+  )
+})
 
 test("sync-schedule skips updates for completed existing races", () => {
   const block = upsertBlock()

--- a/src/app/api/cron/sync-schedule/route.ts
+++ b/src/app/api/cron/sync-schedule/route.ts
@@ -28,15 +28,28 @@ export async function POST(req: NextRequest) {
   // ── 1. Ensure there is an active Season record for the current year ────────
   let season = await db.season.findFirst({
     where: { year },
-    select: { id: true, year: true },
+    select: { id: true, year: true, isActive: true },
   })
 
   if (!season) {
     await db.season.updateMany({ where: { isActive: true }, data: { isActive: false } })
     season = await db.season.create({
       data: { year, isActive: true },
-      select: { id: true, year: true },
+      select: { id: true, year: true, isActive: true },
     })
+  } else if (!season.isActive) {
+    const [, activatedSeason] = await db.$transaction([
+      db.season.updateMany({
+        where: { isActive: true, id: { not: season.id } },
+        data: { isActive: false },
+      }),
+      db.season.update({
+        where: { id: season.id },
+        data: { isActive: true },
+        select: { id: true, year: true, isActive: true },
+      }),
+    ])
+    season = activatedSeason
   }
 
   // ── 2. Fetch sessions + meetings in parallel ───────────────────────────────

--- a/src/lib/f1/providers/openf1.test.mjs
+++ b/src/lib/f1/providers/openf1.test.mjs
@@ -138,6 +138,54 @@ test("getFinalResults defers final classification when stints are empty", async 
   }
 })
 
+test("getFinalResults defers final classification when stints fetch fails", async () => {
+  const previousFetch = globalThis.fetch
+  const previousConsoleError = console.error
+  const errors = []
+  console.error = (...args) => errors.push(args)
+  globalThis.fetch = async (url) => {
+    const requestUrl = String(url)
+
+    if (requestUrl.endsWith("/position?session_key=345")) {
+      return jsonResponse([
+        {
+          session_key: 345,
+          driver_number: 1,
+          position: 1,
+          date: "2026-06-21T15:00:00.000Z",
+        },
+        {
+          session_key: 345,
+          driver_number: 2,
+          position: 2,
+          date: "2026-06-21T15:00:00.000Z",
+        },
+      ])
+    }
+
+    if (requestUrl.endsWith("/stints?session_key=345")) {
+      return new Response("upstream failed", {
+        status: 503,
+        statusText: "Service Unavailable",
+      })
+    }
+
+    return new Response("not found", { status: 404, statusText: "Not Found" })
+  }
+
+  try {
+    const provider = new OpenF1Provider()
+    const results = await provider.getFinalResults(345)
+
+    assert.deepEqual(results, [])
+    assert.equal(errors.length, 1)
+    assert.match(String(errors[0][0]), /deferring final classification/)
+  } finally {
+    globalThis.fetch = previousFetch
+    console.error = previousConsoleError
+  }
+})
+
 test("getLiveClassification returns null when OpenF1 has no position rows", async () => {
   const previousFetch = globalThis.fetch
   globalThis.fetch = async (url) => {

--- a/src/lib/f1/providers/openf1.ts
+++ b/src/lib/f1/providers/openf1.ts
@@ -290,8 +290,12 @@ export class OpenF1Provider implements F1ProviderAdapter {
         }
       }
     } catch (err) {
-      console.error(`[openf1] Stint data unavailable for session ${sessionKey} — all drivers marked CLASSIFIED:`, err)
+      console.error(
+        `[openf1] Stint data unavailable for session ${sessionKey} — deferring final classification:`,
+        err,
+      )
       // Re-ingest after data settles via POST /api/cron/ingest-results { raceId }
+      return []
     }
 
     // 4. Compose final results


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Closes #375 and #377.

Two cron/provider correctness fixes from the 2026-07-24 codebase study.

## Changes
- OpenF1 `/stints` fetch failures now return `[]` so ingestion defers instead of classifying every driver
- `sync-schedule` activates an existing inactive current-year season and deactivates other seasons

## Test plan
- [x] `node --test src/lib/f1/providers/openf1.test.mjs src/app/api/cron/sync-schedule/route.test.mjs src/app/api/cron/sync-schedule/driver-fetch.test.mjs`
- [x] `npx tsc --noEmit`

— gib

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99f35b6a-f0e9-4311-b21c-c3ef948318f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99f35b6a-f0e9-4311-b21c-c3ef948318f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

