### PR TITLE
Add optimistic concurrency for cross-device pick edits

### DIFF
--- a/ai/docs/architecture.md
+++ b/ai/docs/architecture.md
@@ -125,7 +125,8 @@ The retired `/races`, `/leaderboard`, `/picks`, `/profile`, `/signin`, and `/onb
 
 ## API Surface
 
-- `POST /api/picks` — submit pick (auth required)
+- `GET /api/picks?raceId=<id>` — fetch authenticated user's pick; response includes `pick.version` (same value as `updatedAt.toISOString()`) and an `ETag`
+- `POST /api/picks` — submit pick (auth required); existing-row edits require `If-Match: "<pick.version>"` or body `baseVersion`, stale/missing versions return HTTP 409 with `{ currentPick }`
 - `GET /api/races` — public race list
 - `GET /api/races/[id]` — public race detail, including qualifying results and optional entrant season-form fields
 - `GET /api/users/[userId]` — public user profile + picks
@@ -146,6 +147,7 @@ The retired `/races`, `/leaderboard`, `/picks`, `/profile`, `/signin`, and `/onb
 - **Three parallel type systems** — Domain types (`src/types/domain.ts`), Prisma types (DB-only, never leak to client), F1 types (`src/lib/f1/types.ts`). Keep them separate.
 - **Serialization pattern** — `Date` fields cannot cross JSON or RSC/client boundaries. API/native-facing shapes use `Serialized*` variants with dates as ISO strings.
 - **PickSet** unique on `[userId, raceId]` — one pick set per user per race
+- **Pick optimistic concurrency** — API pick responses expose `version = updatedAt.toISOString()`. Cross-device edits must send the loaded version via `If-Match` or `baseVersion`; `pick.service.ts` compares it inside the write transaction before updating.
 - **Race** unique on `[seasonId, round, type]` — separates MAIN and SPRINT
 - **Race ordering is chronological** — service lists/current-race queries sort by `scheduledStartUtc`, not round number. Round labels may be manually renumbered after calendar reconciliation; cancelled rows may be parked at high round values to avoid unique-key collisions.
 - **Two lock levels** — `race.lockCutoffUtc` (race-wide) + `pickSet.lockedAt` (individual)

--- a/ai/docs/worklog.md
+++ b/ai/docs/worklog.md
@@ -31,6 +31,7 @@ Do NOT turn this into a giant diary.
 
 ## Entries
 
+<<<<<<< HEAD
 ### 2026-07-24 — Issue triage, study findings, and parallel fixes
 - by: Codex
 - summary: Filed study findings #375–#379. Opened/pushed fix PRs for #365 (DNF copy), #361 (race API cache), #362 (pick optimistic concurrency), #369 (landing strip + screenshot validator), #375/#377 (OpenF1 stints failure + season activation), #376 (sync-schedule entry guards). Release-polish umbrella #367 remains on draft PR #373 gated by simulator verification #368 and App Store tasks #370–#372.
@@ -38,6 +39,15 @@ Do NOT turn this into a giant diary.
 - verification: per-PR targeted Node suites; several PRs also ran tsc/lint/build as recorded in PR bodies.
 - open questions: #368 still needs Simulator verification; #378/#379 cleanup queued; #361 CDN TTFB thresholds need production measurement after deploy.
 - should update architecture?: no — cache/invalidation details can land when #361 merges
+=======
+### 2026-07-24 18:33 — Pick optimistic concurrency
+- by: Codex
+- summary: Added pick `version`/ETag responses, required base-version checks for existing pick edits inside `createOrUpdatePick`, and returned 409 conflicts with the current server pick. iOS SyncManager now sends `If-Match` from cached authoritative picks and treats 409 as a recoverable conflict.
+- files touched: `src/lib/services/pick.service.ts`, `src/app/api/picks/*`, `src/types/domain.ts`, `ios/FXRacing/Core/Networking`, `ios/FXRacing/Core/Sync/SyncManager.swift`, focused tests, shared architecture docs
+- verification: focused pick route/service/iOS source tests; `npm run test:ios`; `npm run test:services`; `npm run test:routes`; `npx tsc --noEmit`; `npm run lint`; `npm run build`
+- open questions: none
+- should update architecture?: yes — updated
+>>>>>>> 789a6e5 (Add pick optimistic concurrency)
 - should update decisions?: no
 
 ### 2026-07-15 — Browser product UI retired behind the App Store landing

--- a/ios/FXRacing/Core/Models/Pick.swift
+++ b/ios/FXRacing/Core/Models/Pick.swift
@@ -6,8 +6,29 @@ struct Pick: Codable, Sendable {
     let tenthPlaceDriverId: String
     let winnerDriverId: String
     let dnfDriverId: String
+    let version: String?
     let lockedAt: Date?
     let scoreBreakdown: ScoreBreakdown?
+
+    init(
+        id: String,
+        raceId: String,
+        tenthPlaceDriverId: String,
+        winnerDriverId: String,
+        dnfDriverId: String,
+        version: String? = nil,
+        lockedAt: Date?,
+        scoreBreakdown: ScoreBreakdown?
+    ) {
+        self.id = id
+        self.raceId = raceId
+        self.tenthPlaceDriverId = tenthPlaceDriverId
+        self.winnerDriverId = winnerDriverId
+        self.dnfDriverId = dnfDriverId
+        self.version = version
+        self.lockedAt = lockedAt
+        self.scoreBreakdown = scoreBreakdown
+    }
 }
 
 struct ScoreBreakdown: Codable, Sendable {

--- a/ios/FXRacing/Core/Networking/APIClient.swift
+++ b/ios/FXRacing/Core/Networking/APIClient.swift
@@ -82,6 +82,9 @@ struct APIClient: Sendable {
         if let token {
             req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
+        for (field, value) in endpoint.headers {
+            req.setValue(value, forHTTPHeaderField: field)
+        }
         if let body = endpoint.bodyData {
             req.httpBody = body
             req.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/ios/FXRacing/Core/Networking/APIEndpoint.swift
+++ b/ios/FXRacing/Core/Networking/APIEndpoint.swift
@@ -5,17 +5,20 @@ struct APIEndpoint: Sendable {
     let path: String
     let queryItems: [URLQueryItem]
     let bodyData: Data?
+    let headers: [String: String]
 
     init(
         method: String,
         path: String,
         queryItems: [URLQueryItem] = [],
-        bodyData: Data? = nil
+        bodyData: Data? = nil,
+        headers: [String: String] = [:]
     ) {
         self.method = method
         self.path = path
         self.queryItems = queryItems
         self.bodyData = bodyData
+        self.headers = headers
     }
 }
 
@@ -71,7 +74,14 @@ extension APIEndpoint {
         )
     }
 
-    static func submitPick(raceId: String, tenthPlaceDriverId: String, winnerDriverId: String, dnfDriverId: String) -> APIEndpoint {
+    static func submitPick(
+        raceId: String,
+        tenthPlaceDriverId: String,
+        winnerDriverId: String,
+        dnfDriverId: String,
+        baseVersion: String? = nil
+    ) -> APIEndpoint {
+        let headers = baseVersion.map { ["If-Match": "\"\($0)\""] } ?? [:]
         APIEndpoint(
             method: "POST",
             path: "/api/picks",
@@ -80,7 +90,8 @@ extension APIEndpoint {
                 "tenthPlaceDriverId": tenthPlaceDriverId,
                 "winnerDriverId": winnerDriverId,
                 "dnfDriverId": dnfDriverId,
-            ])
+            ]),
+            headers: headers
         )
     }
 

--- a/ios/FXRacing/Core/Sync/SyncManager.swift
+++ b/ios/FXRacing/Core/Sync/SyncManager.swift
@@ -428,12 +428,17 @@ final class SyncManager {
 
             do {
                 guard isCurrent(sessionLease) else { return .queued }
+                let baseVersion = localPickStore.authoritativePick(
+                    for: id.raceID,
+                    owner: .user(currentUserID)
+                )?.version
                 let response: PickResponse = try await api.request(
                     .submitPick(
                         raceId: id.raceID,
                         tenthPlaceDriverId: record.selection.tenthPlaceDriverID,
                         winnerDriverId: record.selection.winnerDriverID,
-                        dnfDriverId: record.selection.dnfDriverID
+                        dnfDriverId: record.selection.dnfDriverID,
+                        baseVersion: baseVersion
                     ),
                     token: token
                 )
@@ -476,6 +481,45 @@ final class SyncManager {
                 )
                 reportUnauthorized(rejectedToken: token)
                 return .unauthorized
+            } catch APIError.serverError(let code, _) where code == 409 {
+                guard isCurrent(sessionLease) else { return .queued }
+                if shouldFollowNewerExplicitRevision(
+                    id: id,
+                    capturedRevision: revision,
+                    localPickStore: localPickStore
+                ) {
+                    continue
+                }
+                let authoritativeResult = await fetchAuthoritativePick(
+                    raceID: id.raceID,
+                    currentUserID: currentUserID,
+                    token: token,
+                    localPickStore: localPickStore,
+                    sessionLease: sessionLease
+                )
+                guard isCurrent(sessionLease) else { return .queued }
+                let authoritativePick: Pick?
+                switch authoritativeResult {
+                case .resolved(let pick):
+                    authoritativePick = pick
+                case .unauthorized:
+                    queueCapturedRevision(
+                        id: id,
+                        revision: revision,
+                        localPickStore: localPickStore,
+                        sessionLease: sessionLease
+                    )
+                    reportUnauthorized(rejectedToken: token)
+                    return .unauthorized
+                }
+                return terminalResult(
+                    .conflict(.serverWins),
+                    id: id,
+                    revision: revision,
+                    localPickStore: localPickStore,
+                    success: .conflict(authoritativePick),
+                    sessionLease: sessionLease
+                )
             } catch APIError.serverError(let code, _) where code == 423 {
                 guard isCurrent(sessionLease) else { return .queued }
                 if shouldFollowNewerExplicitRevision(

--- a/ios/FXRacingTests/Core/Networking/APIClientTests.swift
+++ b/ios/FXRacingTests/Core/Networking/APIClientTests.swift
@@ -128,7 +128,7 @@ final class APIClientTests: XCTestCase {
         let session = URLSession(
             configuration: StubURLProtocol.configuration(
                 status: 200,
-                body: #"{"pick":{"id":"pick","raceId":"race","tenthPlaceDriverId":"p10","winnerDriverId":"winner","dnfDriverId":"dnf","lockedAt":null,"scoreBreakdown":null}}"#
+                body: #"{"pick":{"id":"pick","raceId":"race","tenthPlaceDriverId":"p10","winnerDriverId":"winner","dnfDriverId":"dnf","version":"2026-07-24T18:33:00.000Z","lockedAt":null,"scoreBreakdown":null}}"#
             )
         )
         let client = APIClient(
@@ -143,6 +143,7 @@ final class APIClientTests: XCTestCase {
 
         XCTAssertEqual(payload.pick.id, "pick")
         XCTAssertEqual(payload.pick.raceId, "race")
+        XCTAssertEqual(payload.pick.version, "2026-07-24T18:33:00.000Z")
     }
 }
 

--- a/ios/FXRacingTests/Core/Sync/SyncManagerTests.swift
+++ b/ios/FXRacingTests/Core/Sync/SyncManagerTests.swift
@@ -63,6 +63,46 @@ final class SyncManagerTests: XCTestCase {
         XCTAssertEqual(context.store.record(id: record.id)?.syncState, .confirmed)
     }
 
+    func testExplicitSaveSendsAuthoritativePickVersionAsIfMatch() async throws {
+        let context = makeContext()
+        defer { context.cleanUp() }
+        let record = try saveRecord(in: context.store, owner: .user("user-a"))
+        let baseVersion = "2026-07-24T18:33:00.000Z"
+        XCTAssertTrue(
+            context.store.preserveAuthoritative(
+                pick(
+                    raceID: record.id.raceID,
+                    selection: PickSelection(
+                        winnerDriverID: "piastri",
+                        tenthPlaceDriverID: "leclerc",
+                        dnfDriverID: "norris"
+                    ),
+                    id: "server-baseline",
+                    version: baseVersion
+                ),
+                for: .user("user-a")
+            )
+        )
+        let api = GatedAPIClientSpy(
+            responses: ["POST /api/picks": [.json(PickResponse(pick: pick(for: record)))]]
+        )
+        let manager = SyncManager(api: api, clock: TestClock.fixed)
+
+        guard case .saved = await manager.submitExplicit(
+            id: record.id,
+            revision: record.revision,
+            currentUserID: "user-a",
+            token: "token-a",
+            localPickStore: context.store
+        ) else {
+            return XCTFail("Expected save")
+        }
+
+        let request = try XCTUnwrap(await api.recordedRequests().first)
+        XCTAssertEqual(request.headers["If-Match"], "\"\(baseVersion)\"")
+        XCTAssertNil(try body(from: request)["baseVersion"])
+    }
+
     func testExplicitSaveRejectsWrongOwnerGuestAndTerminalWithoutRequests() async throws {
         let context = makeContext()
         defer { context.cleanUp() }
@@ -1075,6 +1115,50 @@ final class SyncManagerTests: XCTestCase {
         XCTAssertEqual(methods, ["POST", "GET"])
     }
 
+    func testDirect409ReconcilesAuthorityAndMarksConflict() async throws {
+        let context = makeContext()
+        defer { context.cleanUp() }
+        let record = try saveRecord(in: context.store, owner: .user("user-a"))
+        let authoritative = pick(
+            raceID: record.id.raceID,
+            selection: PickSelection(
+                winnerDriverID: "piastri",
+                tenthPlaceDriverID: "leclerc",
+                dnfDriverID: "norris"
+            ),
+            id: "conflicting-server-pick",
+            version: "2026-07-24T18:34:00.000Z"
+        )
+        let api = GatedAPIClientSpy(responses: [
+            "POST /api/picks": [.failure(.serverError(409, "Pick changed"))],
+            "GET /api/picks": [.json(PickResponse(pick: authoritative))],
+        ])
+        let manager = SyncManager(api: api, clock: TestClock.fixed)
+
+        let result = await manager.submitExplicit(
+            id: record.id,
+            revision: record.revision,
+            currentUserID: "user-a",
+            token: "token-a",
+            localPickStore: context.store
+        )
+
+        guard case .conflict(let pick) = result else {
+            return XCTFail("Expected conflict")
+        }
+        XCTAssertEqual(pick?.id, authoritative.id)
+        XCTAssertEqual(context.store.record(id: record.id)?.syncState, .conflict(.serverWins))
+        XCTAssertEqual(
+            context.store.authoritativePick(
+                for: record.id.raceID,
+                owner: .user("user-a")
+            )?.id,
+            authoritative.id
+        )
+        let methods = await api.recordedRequests().map(\.method)
+        XCTAssertEqual(methods, ["POST", "GET"])
+    }
+
     func testKnownLockedRaceExpiresWithoutRequest() async throws {
         let context = makeContext()
         defer { context.cleanUp() }
@@ -1179,7 +1263,8 @@ final class SyncManagerTests: XCTestCase {
     private func pick(
         raceID: String,
         selection: PickSelection,
-        id: String
+        id: String,
+        version: String? = nil
     ) -> Pick {
         Pick(
             id: id,
@@ -1187,6 +1272,7 @@ final class SyncManagerTests: XCTestCase {
             tenthPlaceDriverId: selection.tenthPlaceDriverID,
             winnerDriverId: selection.winnerDriverID,
             dnfDriverId: selection.dnfDriverID,
+            version: version,
             lockedAt: nil,
             scoreBreakdown: nil
         )

--- a/ios/FXRacingTests/Fixtures/GatedAPIClientSpy.swift
+++ b/ios/FXRacingTests/Fixtures/GatedAPIClientSpy.swift
@@ -19,6 +19,7 @@ actor GatedAPIClientSpy: APIRequesting {
         let path: String
         let token: String?
         let query: [String: String]
+        let headers: [String: String]
         let bodyData: Data?
     }
 
@@ -62,6 +63,7 @@ actor GatedAPIClientSpy: APIRequesting {
                 path: endpoint.path,
                 token: token,
                 query: query,
+                headers: endpoint.headers,
                 bodyData: endpoint.bodyData
             )
         )

--- a/ios/api-endpoint-json-body.test.mjs
+++ b/ios/api-endpoint-json-body.test.mjs
@@ -36,3 +36,11 @@ test("JSON-body endpoints use the shared helper", () => {
     assert.doesNotMatch(block, /let body = try\? JSONEncoder\(\)\.encode/)
   }
 })
+
+test("submitPick carries the optimistic concurrency version as If-Match", () => {
+  const block = source.match(/static func submitPick[\s\S]*?private static func jsonBody/)?.[0]
+  assert.ok(block, "submitPick endpoint factory should exist")
+  assert.match(block, /baseVersion:\s*String\?\s*=\s*nil/)
+  assert.match(block, /"If-Match"/)
+  assert.match(block, /headers:\s*headers/)
+})

--- a/src/app/api/picks/post-handler.js
+++ b/src/app/api/picks/post-handler.js
@@ -7,7 +7,32 @@ const PICK_SAVE_DOMAIN_ERRORS = [
   { pattern: /^Race .+ is cancelled/, status: 409 },
   { pattern: /^The following driver IDs are not registered entrants for this race:/, status: 400 },
   { pattern: /^A pick set already exists for this race/, status: 409 },
+  { pattern: /^Invalid pick base version$/, status: 400 },
 ]
+
+function normalizeIfMatch(value) {
+  if (!value) return undefined
+
+  const trimmed = value.trim()
+  if (!trimmed) return undefined
+
+  const quoted = trimmed.match(/^"(.+)"$/)
+  return quoted ? quoted[1] : trimmed
+}
+
+function versionHeaders(pick) {
+  if (!pick?.version) return undefined
+  return { ETag: `"${pick.version}"` }
+}
+
+function isPickConflictError(err) {
+  return Boolean(
+    err &&
+      typeof err === "object" &&
+      err.name === "PickConflictError" &&
+      err.currentPick,
+  )
+}
 
 export async function handlePickPost(
   req,
@@ -34,6 +59,10 @@ export async function handlePickPost(
   let input
   try {
     input = createPickSchema.parse(parsedBody.body)
+    const baseVersion = normalizeIfMatch(req.headers.get("if-match"))
+    if (baseVersion) {
+      input = { ...input, baseVersion }
+    }
   } catch (err) {
     if (isValidationError(err)) {
       return Response.json(
@@ -46,8 +75,15 @@ export async function handlePickPost(
 
   try {
     const pick = await createOrUpdatePick(session.user.id, input)
-    return Response.json({ pick })
+    return Response.json({ pick }, { headers: versionHeaders(pick) })
   } catch (err) {
+    if (isPickConflictError(err)) {
+      return Response.json(
+        { error: err.message, currentPick: err.currentPick },
+        { status: 409, headers: versionHeaders(err.currentPick) },
+      )
+    }
+
     return sanitizedErrorResponse(err, {
       domainErrors: PICK_SAVE_DOMAIN_ERRORS,
       fallbackMessage: "Failed to save pick",

--- a/src/app/api/picks/post-handler.test.mjs
+++ b/src/app/api/picks/post-handler.test.mjs
@@ -8,6 +8,7 @@ function dependencies(overrides = {}) {
   return {
     ...authedDeps("user-1"),
     createPickSchema: { parse: (body) => body },
+    createOrUpdatePick: async () => ({ id: "pick-1", version: "version-1" }),
     isValidationError: () => false,
     getValidationIssues: () => [],
     logger: { error: () => {} },
@@ -15,8 +16,8 @@ function dependencies(overrides = {}) {
   }
 }
 
-function pickRequest(body) {
-  return jsonRequest("http://localhost/api/picks", body)
+function pickRequest(body, options = {}) {
+  return jsonRequest("http://localhost/api/picks", body, options)
 }
 
 function rawPickRequest(body) {
@@ -101,5 +102,51 @@ test("POST preserves pick validation domain errors", async () => {
   assert.equal(response.status, 400)
   assert.deepEqual(await responseJson(response), {
     error: "The following driver IDs are not registered entrants for this race: driver-1",
+  })
+})
+
+test("POST passes If-Match as the pick base version and returns the saved version", async () => {
+  let receivedInput
+  const response = await handlePickPost(
+    pickRequest(
+      { raceId: "race-1", baseVersion: "body-version" },
+      { headers: { "if-match": "\"header-version\"" } },
+    ),
+    dependencies({
+      createOrUpdatePick: async (_userId, input) => {
+        receivedInput = input
+        return { id: "pick-1", version: "saved-version" }
+      },
+    }),
+  )
+
+  assert.equal(response.status, 200)
+  assert.equal(response.headers.get("etag"), "\"saved-version\"")
+  assert.equal(receivedInput.baseVersion, "header-version")
+})
+
+test("POST returns recoverable pick conflicts with the current server pick", async () => {
+  const currentPick = {
+    id: "pick-1",
+    raceId: "race-1",
+    version: "server-version",
+    winnerDriverId: "winner",
+    tenthPlaceDriverId: "p10",
+    dnfDriverId: "dnf",
+  }
+  const response = await handlePickPost(pickRequest({ raceId: "race-1" }), dependencies({
+    createOrUpdatePick: async () => {
+      const err = new Error("Pick has changed since it was loaded; refresh and try again")
+      err.name = "PickConflictError"
+      err.currentPick = currentPick
+      throw err
+    },
+  }))
+
+  assert.equal(response.status, 409)
+  assert.equal(response.headers.get("etag"), "\"server-version\"")
+  assert.deepEqual(await responseJson(response), {
+    error: "Pick has changed since it was loaded; refresh and try again",
+    currentPick,
   })
 })

--- a/src/app/api/picks/route.ts
+++ b/src/app/api/picks/route.ts
@@ -48,5 +48,8 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "Pick not found" }, { status: 404 })
   }
 
-  return NextResponse.json({ pick })
+  return NextResponse.json(
+    { pick },
+    { headers: { ETag: `"${pick.version}"` } },
+  )
 }

--- a/src/lib/services/pick.service.test.mjs
+++ b/src/lib/services/pick.service.test.mjs
@@ -50,3 +50,41 @@ test("createOrUpdatePick reasserts cancelled race guards for update and create w
   assert.doesNotMatch(createOrUpdatePickBody, /createPickSetIfRaceWritable/)
   assert.match(createOrUpdatePickBody, /if \(race\.status === ['"]CANCELLED['"]\)[\s\S]*?tx\.pickSet\.create/)
 })
+
+test("createOrUpdatePick exposes and validates a base version for optimistic concurrency", () => {
+  assert.match(source, /export function pickVersion\(updatedAt: Date\): string \{\s*return updatedAt\.toISOString\(\)/)
+  assert.match(
+    source,
+    /baseVersion:\s*z\.string\(\)\.min\(1\)\.optional\(\)/,
+  )
+  assert.match(source, /export class PickConflictError extends Error/)
+  assert.match(source, /this\.currentPick = currentPick/)
+  assert.match(createOrUpdatePickBody, /const baseUpdatedAt = parseBasePickVersion\(validated\.baseVersion\)/)
+})
+
+test("createOrUpdatePick compares base version inside the pick transaction before updating", () => {
+  const transactionStart = createOrUpdatePickBody.indexOf("return db.$transaction")
+  const existingLookup = createOrUpdatePickBody.indexOf("const existingPickSet = await tx.pickSet.findUnique")
+  const conflictThrow = createOrUpdatePickBody.indexOf("throw new PickConflictError(mapPickSetToData(existingPickSet))")
+  const updateWrite = createOrUpdatePickBody.indexOf("tx.pickSet.updateMany")
+
+  assert.ok(transactionStart >= 0)
+  assert.ok(existingLookup > transactionStart)
+  assert.ok(conflictThrow > existingLookup)
+  assert.ok(conflictThrow < updateWrite)
+  assert.match(
+    createOrUpdatePickBody,
+    /existingPickSet\.updatedAt\.getTime\(\) !== baseUpdatedAt\.getTime\(\)/,
+  )
+})
+
+test("createOrUpdatePick keeps simultaneous edits guarded by the submitted version", () => {
+  assert.match(
+    createOrUpdatePickBody,
+    /\.\.\.\(baseUpdatedAt \? \{ updatedAt: baseUpdatedAt \} : \{\}\)/,
+  )
+  assert.match(
+    createOrUpdatePickBody,
+    /only the request whose base version still matches[\s\S]*?lockedAt IS NULL succeeds/,
+  )
+})

--- a/src/lib/services/pick.service.ts
+++ b/src/lib/services/pick.service.ts
@@ -32,8 +32,32 @@ export class PickLockedError extends Error {
   }
 }
 
+export class PickConflictError extends Error {
+  readonly currentPick: PickSetData
+
+  constructor(currentPick: PickSetData) {
+    super('Pick has changed since it was loaded; refresh and try again')
+    this.name = 'PickConflictError'
+    this.currentPick = currentPick
+  }
+}
+
 function cancelledRacePickMessage(raceId: string): string {
   return `Race ${raceId} is cancelled — picks can no longer be submitted`
+}
+
+export function pickVersion(updatedAt: Date): string {
+  return updatedAt.toISOString()
+}
+
+function parseBasePickVersion(baseVersion: string | undefined): Date | null {
+  if (!baseVersion) return null
+
+  const parsed = new Date(baseVersion)
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error('Invalid pick base version')
+  }
+  return parsed
 }
 
 // ─────────────────────────────────────────────
@@ -46,6 +70,7 @@ export const CreatePickSchema = z
     tenthPlaceDriverId: z.string().min(1),
     winnerDriverId: z.string().min(1),
     dnfDriverId: z.string().min(1),
+    baseVersion: z.string().min(1).optional(),
   })
   .refine(
     (data) => {
@@ -94,6 +119,7 @@ function mapPickSetToData(
     dnfSeatKey: ps.dnfSeatKey,
     createdAt: ps.createdAt,
     updatedAt: ps.updatedAt,
+    version: pickVersion(ps.updatedAt),
     lockedAt: ps.lockedAt,
     lockedSubmittedBeforeQualifying: ps.lockedSubmittedBeforeQualifying ?? null,
   }
@@ -187,6 +213,7 @@ export async function createOrUpdatePick(
 ): Promise<PickSetData> {
   // 1. Validate input
   const validated = CreatePickSchema.parse(input)
+  const baseUpdatedAt = parseBasePickVersion(validated.baseVersion)
 
   return db.$transaction(async (tx) => {
     // 2. Load and lock race. This serializes race status changes with both
@@ -244,14 +271,35 @@ export async function createOrUpdatePick(
         seatLookup.driverIdToSeatKey.get(validated.dnfDriverId) ?? null,
     }
 
+    const existingPickSet = await tx.pickSet.findUnique({
+      where: { userId_raceId: { userId, raceId: validated.raceId } },
+    })
+
+    if (existingPickSet) {
+      if (isPickSetLocked(existingPickSet.lockedAt)) {
+        throw new PickLockedError(
+          'This pick set has been locked and can no longer be edited',
+        )
+      }
+
+      if (
+        !baseUpdatedAt ||
+        existingPickSet.updatedAt.getTime() !== baseUpdatedAt.getTime()
+      ) {
+        throw new PickConflictError(mapPickSetToData(existingPickSet))
+      }
+    }
+
     // 5. Atomic guarded update — re-asserts both invariants at the DB level.
     // Two concurrent submits at lockCutoff − Δ both pass the JS check above,
-    // but only the request whose write commits while lockCutoffUtc > now(),
-    // status is not CANCELLED, and lockedAt IS NULL succeeds.
+    // but only the request whose base version still matches and whose write
+    // commits while lockCutoffUtc > now(), status is not CANCELLED, and
+    // lockedAt IS NULL succeeds.
     const updated = await tx.pickSet.updateMany({
       where: {
         userId,
         raceId: validated.raceId,
+        ...(baseUpdatedAt ? { updatedAt: baseUpdatedAt } : {}),
         lockedAt: null,
         race: {
           lockCutoffUtc: { gt: new Date() },

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -116,6 +116,8 @@ export type PickSetData = {
   dnfSeatKey: string | null
   createdAt: Date
   updatedAt: Date
+  /** Stable optimistic-concurrency token derived from updatedAt. */
+  version: string
   /** Set when the pick set is locked; null means still editable */
   lockedAt: Date | null
   /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Closes #362.

Adds optimistic concurrency so a second-device pick edit cannot silently overwrite a newer server pick.

## API contract
- Pick responses include `pick.version` (`updatedAt` ISO) and `ETag`
- Existing-pick `POST` requires `If-Match` or body `baseVersion`
- Stale/missing base version → `409` with `{ error, currentPick }`
- First create still allowed without a base version
- Lock remains `423`; gameplay/scoring unchanged

## iOS
- `SyncManager` sends `If-Match` from the cached authoritative server pick
- `409` enters the existing recoverable conflict flow

## Test plan
- [x] pick service + post-handler tests
- [x] `npm run test:ios` / `test:services` / `test:routes`
- [x] `npx tsc --noEmit` / `npm run lint` / `npm run build`

— gib

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99f35b6a-f0e9-4311-b21c-c3ef948318f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99f35b6a-f0e9-4311-b21c-c3ef948318f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

