### PR TITLE
Fix race-id leaderboard sorting and double rank compute

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:utils": "node --test src/lib/observability/client-errors.test.mjs",
     "test:scoring": "node --test src/lib/scoring/formula.test.mjs",
     "test:scripts:static": "node --test scripts/app-store-screenshots.test.mjs scripts/backfill-locked-snapshots.test.mjs scripts/cleanup-orphaned-races.test.mjs scripts/db-entrypoint.test.mjs scripts/find-cheated-picks.test.mjs scripts/install-pickset-triggers.test.mjs scripts/maintenance-season-guards.test.mjs scripts/tsconfig-prisma-coverage.test.mjs scripts/vercel-cli-doc.test.mjs",
-    "test:services": "node --test src/lib/services/pick.service.test.mjs src/lib/services/race.service.test.mjs src/lib/services/race-summary.mapper.test.mjs src/lib/services/driver-season-stats.test.mjs src/lib/services/user.service.test.mjs src/lib/services/leaderboard-rank.test.mjs src/lib/services/friendship.service.test.mjs src/lib/services/qualifying.service.test.mjs src/lib/services/scoring-pick-resolution.test.mjs src/lib/services/scoring.service.test.mjs src/lib/f1/providers/openf1.test.mjs",
+    "test:services": "node --test src/lib/services/pick.service.test.mjs src/lib/services/race.service.test.mjs src/lib/services/race-summary.mapper.test.mjs src/lib/services/driver-season-stats.test.mjs src/lib/services/user.service.test.mjs src/lib/services/leaderboard-rank.test.mjs src/lib/services/leaderboard.service.test.mjs src/lib/services/friendship.service.test.mjs src/lib/services/qualifying.service.test.mjs src/lib/services/scoring-pick-resolution.test.mjs src/lib/services/scoring.service.test.mjs src/lib/f1/providers/openf1.test.mjs",
     "lint": "next lint",
     "db:push": "prisma db push",
     "db:studio": "prisma studio"

--- a/src/app/api/leaderboard/get-handler.js
+++ b/src/app/api/leaderboard/get-handler.js
@@ -4,9 +4,10 @@ export async function handleLeaderboardGet(
     auth,
     mobileAuth,
     getActiveSeason,
-    getGlobalLeaderboard,
+    getGlobalLeaderboardResult,
     getFriendsLeaderboard,
     getUserLeaderboardRank,
+    validateLeaderboardSort,
   },
 ) {
   const { searchParams } = request.nextUrl
@@ -31,13 +32,19 @@ export async function handleLeaderboardGet(
     return Response.json({ rows: [], userRank: null, userRow: null })
   }
 
-  const rows =
+  if (!(await validateLeaderboardSort(seasonId, sort))) {
+    return Response.json({ error: "Invalid race id" }, { status: 400 })
+  }
+
+  const leaderboard =
     scope === "friends"
-      ? await getFriendsLeaderboard(userId, seasonId, sort)
-      : await getGlobalLeaderboard(seasonId, sort, 20)
+      ? {
+          rows: await getFriendsLeaderboard(userId, seasonId, sort),
+          userRank: userId ? await getUserLeaderboardRank(userId, seasonId, sort) : null,
+        }
+      : await getGlobalLeaderboardResult(seasonId, sort, 20, userId)
 
-  const userRank = userId ? await getUserLeaderboardRank(userId, seasonId, sort) : null
-  const userRow = userId ? (rows.find((row) => row.userId === userId) ?? null) : null
+  const userRow = userId ? (leaderboard.rows.find((row) => row.userId === userId) ?? null) : null
 
-  return Response.json({ rows, userRank, userRow })
+  return Response.json({ rows: leaderboard.rows, userRank: leaderboard.userRank, userRow })
 }

--- a/src/app/api/leaderboard/get-handler.test.mjs
+++ b/src/app/api/leaderboard/get-handler.test.mjs
@@ -14,47 +14,55 @@ function dependencies(overrides = {}) {
     auth: async () => ({ user: { id: "user-1" } }),
     mobileAuth: async () => null,
     getActiveSeason: async () => ({ id: "season-1" }),
-    getGlobalLeaderboard: async () => [],
+    getGlobalLeaderboardResult: async () => ({ rows: [], userRank: null }),
     getFriendsLeaderboard: async () => [],
     getUserLeaderboardRank: async () => null,
+    validateLeaderboardSort: async () => true,
     ...overrides,
   }
 }
 
-test("GET uses the requested race sort when computing userRank", async () => {
-  const rankCalls = []
+test("GET returns global rows and userRank from the combined leaderboard result", async () => {
+  const globalCalls = []
   const response = await handleLeaderboardGet(
     request("http://localhost/api/leaderboard?sort=race-1&seasonId=season-1"),
     dependencies({
-      getGlobalLeaderboard: async (_seasonId, sort) => [
-        { userId: "user-1", rank: sort === "race-1" ? 3 : 9 },
-      ],
-      getUserLeaderboardRank: async (userId, seasonId, sort) => {
-        rankCalls.push({ userId, seasonId, sort })
-        return sort === "race-1" ? 3 : 9
+      getGlobalLeaderboardResult: async (seasonId, sort, limit, userId) => {
+        globalCalls.push({ seasonId, sort, limit, userId })
+        return {
+          rows: [{ userId: "user-1", rank: sort === "race-1" ? 3 : 9 }],
+          userRank: sort === "race-1" ? 3 : 9,
+        }
+      },
+      getUserLeaderboardRank: async () => {
+        throw new Error("global requests should not recompute user rank")
       },
     }),
   )
 
   assert.equal(response.status, 200)
-  assert.deepEqual(rankCalls, [{ userId: "user-1", seasonId: "season-1", sort: "race-1" }])
+  assert.deepEqual(globalCalls, [
+    { seasonId: "season-1", sort: "race-1", limit: 20, userId: "user-1" },
+  ])
   assert.equal((await response.json()).userRank, 3)
 })
 
-test("GET keeps season as the default userRank sort", async () => {
-  const rankCalls = []
+test("GET keeps season as the default leaderboard sort", async () => {
+  const globalCalls = []
   const response = await handleLeaderboardGet(
     request("http://localhost/api/leaderboard?seasonId=season-1"),
     dependencies({
-      getUserLeaderboardRank: async (userId, seasonId, sort) => {
-        rankCalls.push({ userId, seasonId, sort })
-        return 2
+      getGlobalLeaderboardResult: async (seasonId, sort, limit, userId) => {
+        globalCalls.push({ seasonId, sort, limit, userId })
+        return { rows: [], userRank: 2 }
       },
     }),
   )
 
   assert.equal(response.status, 200)
-  assert.deepEqual(rankCalls, [{ userId: "user-1", seasonId: "season-1", sort: "season" }])
+  assert.deepEqual(globalCalls, [
+    { seasonId: "season-1", sort: "season", limit: 20, userId: "user-1" },
+  ])
   assert.equal((await response.json()).userRank, 2)
 })
 
@@ -66,9 +74,9 @@ test("GET allows unauthenticated global leaderboard reads", async () => {
     dependencies({
       auth: async () => null,
       mobileAuth: async () => null,
-      getGlobalLeaderboard: async (seasonId, sort, limit) => {
-        globalCalls.push({ seasonId, sort, limit })
-        return [{ userId: "user-2", rank: 1 }]
+      getGlobalLeaderboardResult: async (seasonId, sort, limit, userId) => {
+        globalCalls.push({ seasonId, sort, limit, userId })
+        return { rows: [{ userId: "user-2", rank: 1 }], userRank: null }
       },
       getUserLeaderboardRank: async (...args) => {
         rankCalls.push(args)
@@ -78,7 +86,9 @@ test("GET allows unauthenticated global leaderboard reads", async () => {
   )
 
   assert.equal(response.status, 200)
-  assert.deepEqual(globalCalls, [{ seasonId: "season-1", sort: "season", limit: 20 }])
+  assert.deepEqual(globalCalls, [
+    { seasonId: "season-1", sort: "season", limit: 20, userId: null },
+  ])
   assert.deepEqual(rankCalls, [])
   assert.deepEqual(await response.json(), {
     rows: [{ userId: "user-2", rank: 1 }],
@@ -104,4 +114,31 @@ test("GET requires authentication for friends leaderboard reads", async () => {
   assert.equal(response.status, 401)
   assert.deepEqual(friendsCalls, [])
   assert.deepEqual(await response.json(), { error: "Unauthorized" })
+})
+
+test("GET rejects invalid race sort values before loading leaderboard rows", async () => {
+  const calls = []
+  const response = await handleLeaderboardGet(
+    request("http://localhost/api/leaderboard?sort=not-a-race&seasonId=season-1"),
+    dependencies({
+      validateLeaderboardSort: async (seasonId, sort) => {
+        calls.push({ fn: "validateLeaderboardSort", seasonId, sort })
+        return false
+      },
+      getGlobalLeaderboardResult: async () => {
+        calls.push({ fn: "getGlobalLeaderboardResult" })
+        return { rows: [], userRank: null }
+      },
+      getUserLeaderboardRank: async () => {
+        calls.push({ fn: "getUserLeaderboardRank" })
+        return null
+      },
+    }),
+  )
+
+  assert.equal(response.status, 400)
+  assert.deepEqual(calls, [
+    { fn: "validateLeaderboardSort", seasonId: "season-1", sort: "not-a-race" },
+  ])
+  assert.deepEqual(await response.json(), { error: "Invalid race id" })
 })

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -2,9 +2,10 @@ import { NextRequest } from 'next/server'
 import { auth } from '@/auth'
 import { mobileAuth } from '@/lib/auth/mobileAuth'
 import {
-  getGlobalLeaderboard,
+  getGlobalLeaderboardResult,
   getFriendsLeaderboard,
   getUserLeaderboardRank,
+  validateLeaderboardSort,
 } from '@/lib/services/leaderboard.service'
 import { getActiveSeason } from '@/lib/services/race.service'
 import { handleLeaderboardGet } from './get-handler'
@@ -14,8 +15,9 @@ export async function GET(request: NextRequest) {
     auth,
     mobileAuth,
     getActiveSeason,
-    getGlobalLeaderboard,
+    getGlobalLeaderboardResult,
     getFriendsLeaderboard,
     getUserLeaderboardRank,
+    validateLeaderboardSort,
   })
 }

--- a/src/lib/services/leaderboard.service.test.mjs
+++ b/src/lib/services/leaderboard.service.test.mjs
@@ -1,0 +1,72 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const source = await readFile(new URL("./leaderboard.service.ts", import.meta.url), "utf8")
+
+function serviceBlock(startText, endText) {
+  const start = source.indexOf(startText)
+  const end = source.indexOf(endText, start)
+
+  assert.notEqual(start, -1, `${startText} source block should exist`)
+  assert.notEqual(end, -1, `${endText} source block should follow ${startText}`)
+
+  return source.slice(start, end)
+}
+
+test("race-specific global leaderboards seed users from scored pick sets for that race", () => {
+  const userIdBlock = serviceBlock(
+    "async function getScoredUserIdsForSort",
+    "async function getRankedGlobalLeaderboard",
+  )
+  const globalBlock = serviceBlock(
+    "async function getRankedGlobalLeaderboard",
+    "/**\n * Get the global leaderboard",
+  )
+
+  assert.match(
+    source,
+    /function raceWhereForSort\(seasonId: string, sort: string\) \{\s*return sort === 'season'\s*\?\s*\{ seasonId, status: 'COMPLETED' as const \}\s*:\s*\{ seasonId, status: 'COMPLETED' as const, id: sort \s*\}/,
+  )
+  assert.match(userIdBlock, /race: raceWhereForSort\(seasonId, sort\)/)
+  assert.match(userIdBlock, /scoreBreakdown: \{ isNot: null \}/)
+  assert.match(userIdBlock, /distinct: \['userId'\]/)
+  assert.match(globalBlock, /const userIds = await getScoredUserIdsForSort\(seasonId, sort\)/)
+  assert.doesNotMatch(globalBlock, /race:\s*\{\s*seasonId\s*\}/)
+})
+
+test("race-specific friends leaderboards keep only friends scored for that race", () => {
+  const friendsBlock = serviceBlock(
+    "export async function getFriendsLeaderboard",
+    "export async function validateLeaderboardSort",
+  )
+
+  assert.match(
+    friendsBlock,
+    /const leaderboardUserIds =\s*sort === 'season' \? allIds : await getScoredUserIdsForSort\(seasonId, sort, allIds\)/,
+  )
+  assert.match(friendsBlock, /const rows = await aggregateScores\(leaderboardUserIds, seasonId, sort\)/)
+})
+
+test("leaderboard sort validation accepts season or a race in the selected season", () => {
+  const validateBlock = serviceBlock(
+    "export async function validateLeaderboardSort",
+    "/**\n * Get a single user's rank",
+  )
+
+  assert.match(validateBlock, /if \(sort === 'season'\) return true/)
+  assert.match(validateBlock, /db\.race\.findFirst\(\{\s*where: \{ id: sort, seasonId \}/)
+  assert.match(validateBlock, /return Boolean\(race\)/)
+})
+
+test("global leaderboard result derives rows and userRank from one ranked aggregation", () => {
+  const resultBlock = serviceBlock(
+    "export async function getGlobalLeaderboardResult",
+    "/**\n * Get the leaderboard for a user",
+  )
+
+  assert.match(resultBlock, /const rankedRows = await getRankedGlobalLeaderboard\(seasonId, sort\)/)
+  assert.match(resultBlock, /rankedRows\.find\(\(row\) => row\.userId === userId\)\?\.rank/)
+  assert.match(resultBlock, /rows: rankedRows\.slice\(0, limit\)/)
+  assert.doesNotMatch(resultBlock, /getUserLeaderboardRank/)
+})

--- a/src/lib/services/leaderboard.service.ts
+++ b/src/lib/services/leaderboard.service.ts
@@ -38,9 +38,6 @@ type AggregatedRow = {
 
 /**
  * Aggregate scores for a set of user IDs in a given season.
- * If `lastRaceOnly` is true, only the most recently completed race is counted.
- */
-/**
  * filter: 'season' = all completed races, any other string = specific raceId
  */
 async function aggregateScores(
@@ -55,12 +52,6 @@ async function aggregateScores(
     filter === 'season'
       ? { seasonId, status: 'COMPLETED' as const }
       : { seasonId, status: 'COMPLETED' as const, id: filter }
-
-  // If filtering to a specific race, verify it exists
-  if (filter !== 'season') {
-    const exists = await db.race.findFirst({ where: raceWhere, select: { id: true } })
-    if (!exists) return await buildZeroedRows(userIds)
-  }
 
   // Load all pick sets with score breakdowns and race type info for the target users
   const pickSets = await db.pickSet.findMany({
@@ -138,27 +129,39 @@ async function aggregateScores(
   return Array.from(aggregated.values())
 }
 
-/** Build zeroed rows for users when there are no completed races */
-async function buildZeroedRows(userIds: string[]): Promise<AggregatedRow[]> {
-  const users = await db.user.findMany({
-    where: { id: { in: userIds } },
-    select: { id: true, publicUsername: true, image: true, favoriteTeamSlug: true },
+function raceWhereForSort(seasonId: string, sort: string) {
+  return sort === 'season'
+    ? { seasonId, status: 'COMPLETED' as const }
+    : { seasonId, status: 'COMPLETED' as const, id: sort }
+}
+
+async function getScoredUserIdsForSort(
+  seasonId: string,
+  sort: string,
+  userIds?: string[],
+): Promise<string[]> {
+  const pickSets = await db.pickSet.findMany({
+    where: {
+      ...(userIds ? { userId: { in: userIds } } : {}),
+      race: raceWhereForSort(seasonId, sort),
+      scoreBreakdown: { isNot: null },
+    },
+    select: { userId: true },
+    distinct: ['userId'],
   })
 
-  return users.map((u) => {
-    const team = u.favoriteTeamSlug ? TEAMS[u.favoriteTeamSlug as TeamSlug] : null
-    return {
-      userId: u.id,
-      publicUsername: u.publicUsername,
-      avatarUrl: u.image,
-      teamLogoUrl: team?.logoUrl ?? null,
-      teamColor: team?.color ?? null,
-      totalScore: 0,
-      exactTenthHits: 0,
-      winnerHits: 0,
-      dnfHits: 0,
-    }
-  })
+  return pickSets.map((r) => r.userId)
+}
+
+async function getRankedGlobalLeaderboard(
+  seasonId: string,
+  sort: string,
+): Promise<LeaderboardRow[]> {
+  const userIds = await getScoredUserIdsForSort(seasonId, sort)
+  if (userIds.length === 0) return []
+
+  const rows = await aggregateScores(userIds, seasonId, sort)
+  return rankRows(rows)
 }
 
 // ─────────────────────────────────────────────
@@ -178,21 +181,25 @@ export async function getGlobalLeaderboard(
   sort: string,
   limit = 20,
 ): Promise<LeaderboardRow[]> {
-  // Find all users who have submitted at least one scored pick in this season
-  const userIdsRaw = await db.pickSet.findMany({
-    where: {
-      race: { seasonId },
-      scoreBreakdown: { isNot: null },
-    },
-    select: { userId: true },
-    distinct: ['userId'],
-  })
+  const rows = await getRankedGlobalLeaderboard(seasonId, sort)
+  return rows.slice(0, limit)
+}
 
-  const userIds = userIdsRaw.map((r) => r.userId)
-  if (userIds.length === 0) return []
+export async function getGlobalLeaderboardResult(
+  seasonId: string,
+  sort: string,
+  limit = 20,
+  userId: string | null = null,
+): Promise<{ rows: LeaderboardRow[]; userRank: number | null }> {
+  const rankedRows = await getRankedGlobalLeaderboard(seasonId, sort)
+  const userRank = userId
+    ? (rankedRows.find((row) => row.userId === userId)?.rank ?? null)
+    : null
 
-  const rows = await aggregateScores(userIds, seasonId, sort)
-  return rankRows(rows).slice(0, limit)
+  return {
+    rows: rankedRows.slice(0, limit),
+    userRank,
+  }
 }
 
 /**
@@ -218,9 +225,22 @@ export async function getFriendsLeaderboard(
 
   // Include the requesting user themselves
   const allIds = Array.from(new Set([userId, ...friendIds]))
+  const leaderboardUserIds =
+    sort === 'season' ? allIds : await getScoredUserIdsForSort(seasonId, sort, allIds)
 
-  const rows = await aggregateScores(allIds, seasonId, sort)
+  const rows = await aggregateScores(leaderboardUserIds, seasonId, sort)
   return rankRows(rows)
+}
+
+export async function validateLeaderboardSort(seasonId: string, sort: string): Promise<boolean> {
+  if (sort === 'season') return true
+
+  const race = await db.race.findFirst({
+    where: { id: sort, seasonId },
+    select: { id: true },
+  })
+
+  return Boolean(race)
 }
 
 /**
@@ -232,7 +252,7 @@ export async function getUserLeaderboardRank(
   seasonId: string,
   sort: string,
 ): Promise<number | null> {
-  const leaderboard = await getGlobalLeaderboard(seasonId, sort, 10_000)
+  const leaderboard = await getRankedGlobalLeaderboard(seasonId, sort)
   const entry = leaderboard.find((row) => row.userId === userId)
   return entry?.rank ?? null
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Closes #378.

## Changes
- Invalid non-`season` `sort` values return `400 { error: "Invalid race id" }`
- Race-specific leaderboards seed only users scored for that race
- Authenticated global responses compute `{ rows, userRank }` in one pass (no second 10k recompute)

## Test plan
- [x] leaderboard handler + service tests
- [x] `npm run test:services` / `test:routes`
- [x] `npx tsc --noEmit`

— gib

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99f35b6a-f0e9-4311-b21c-c3ef948318f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99f35b6a-f0e9-4311-b21c-c3ef948318f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

