### PR TITLE
Document public race API caching decision

### DIFF
--- a/ai/docs/architecture.md
+++ b/ai/docs/architecture.md
@@ -128,6 +128,7 @@ The retired `/races`, `/leaderboard`, `/picks`, `/profile`, `/signin`, and `/onb
 - `GET /api/picks?raceId=<id>` — fetch authenticated user's pick; response includes `pick.version` (same value as `updatedAt.toISOString()`) and an `ETag`
 - `POST /api/picks` — submit pick (auth required); existing-row edits require `If-Match: "<pick.version>"` or body `baseVersion`, stale/missing versions return HTTP 409 with `{ currentPick }`
 - `GET /api/races` — public race list
+- Public race GETs (`/api/races`, `/api/races/[id]`) bypass Auth.js middleware, set shared Cache-Control (`s-maxage` + `stale-while-revalidate`), emit Server-Timing, and are invalidated via cache tags after schedule/status/entry/qualifying/result mutations.
 - `GET /api/races/[id]` — public race detail, including qualifying results and optional entrant season-form fields
 - `GET /api/users/[userId]` — public user profile + picks
 - `GET /api/friends` — friend list (auth required)

--- a/ai/docs/decisions.md
+++ b/ai/docs/decisions.md
@@ -19,6 +19,16 @@ Do not log temporary debugging notes here.
 
 ## Entries
 
+
+### 2026-07-25 — Public race API CDN caching and Auth.js bypass
+- Status: accepted
+- Context: Production `/api/races` warm-origin TTFB stayed ~1s and responses set avoidable Auth.js cookies despite being public.
+- Decision: Bypass Auth.js middleware for public race GETs; set status-aware shared Cache-Control with stale-while-revalidate; tag and revalidate after schedule/status/entry/qualifying/result mutations; expose Server-Timing. Keep private user/pick responses `private, no-store`.
+- Reason: First-install and origin latency dominate native hydration; CDN caching is safe for public schedule/detail with short live TTLs.
+- Tradeoffs: Live status can lag by cache TTL plus client 60s poll; invalidation must stay hooked to every mutating cron.
+- Affected areas: `src/middleware.ts`, `src/app/api/races/*`, cron routes that call `revalidateTag`.
+- Follow-up: Measure production CDN-hit TTFB p95 ≤ 250 ms and cache hit rate ≥ 90% outside live windows (#361).
+
 ### 2026-07-15 — iOS-first product with a static web surface
 - Status: accepted
 - Context: Gameplay is delivered by the native iOS app; maintaining a second browser product added client bundles, runtime work, dependencies, and duplicated UX without being part of the desired product direction.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Documents the accepted public race CDN caching / Auth.js bypass decision after #381 deployed.

Refs #361

Production probe after deploy:
- no `Set-Cookie` on `/api/races`
- `x-vercel-cache: HIT` warm samples ~90–260 ms
- `Server-Timing` present

— gib

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99f35b6a-f0e9-4311-b21c-c3ef948318f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99f35b6a-f0e9-4311-b21c-c3ef948318f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

