### PR TITLE
Make public race caching honestly TTL-only

### DIFF
--- a/ai/docs/decisions.md
+++ b/ai/docs/decisions.md
@@ -20,6 +20,15 @@ Do not log temporary debugging notes here.
 ## Entries
 
 
+### 2026-07-26 — Public race caching is TTL-only; tags are for manual purge
+- Status: accepted
+- Context: #361 shipped CDN caching plus what looked like targeted invalidation: responses carried a `Cache-Tag` header and the four race-mutating crons called `revalidatePublicRaceCache()`, which called `revalidateTag()`. Both halves were inert. `revalidateTag()` only purges the Next.js Data Cache, and `git grep` finds no `unstable_cache` / `'use cache'` / `cacheTag` anywhere in `src/` — these are plain dynamic route handlers whose caching is purely the CDN honouring `s-maxage`, so there was no registered entry to purge. Separately, Vercel reads `Vercel-Cache-Tag`; a bare `Cache-Tag` is the Cloudflare/Fastly convention and is ignored. The code therefore read as if invalidation worked when nothing could purge anything (#392).
+- Decision: Make public race caching explicitly TTL-only. Removed `revalidatePublicRaceCache()` and its four cron call sites, and the `next/cache` import. Renamed the response header to `Vercel-Cache-Tag` so the tags are genuinely purgeable on demand via `vercel cache invalidate --tag public-race:<raceId>` or `POST /v1/edge-cache/invalidate-by-tags`. Crons now log `staleTags=` naming exactly which tags a run invalidated, so an operator can purge deliberately.
+- Reason: Prefer a small honest mechanism over a larger one that only appears to work. Automatic purge would need a Vercel API token in the cron environment, and the TTLs already bound staleness tightly: a status transition is bounded by the *previous* status's TTL, so a race going LIVE → COMPLETED is visible within ~15s, and the list within ~60s.
+- Tradeoffs: No automatic purge. If a mutation must be visible sooner than its TTL, someone runs the documented purge command. If that proves too manual, the follow-up is to wire the edge-cache invalidate API into `revalidatePublicRaceCache()` with a scoped token — the tags are now correct, so only the trigger would be missing.
+- Affected areas: `src/lib/api/public-race-cache.ts`, the four cron routes under `src/app/api/cron/`, `src/app/api/races/route-source.test.mjs`.
+- Follow-up: Revisit if #361's production hit-rate measurement shows staleness complaints rather than cache misses.
+
 ### 2026-07-25 — Public race API CDN caching and Auth.js bypass
 - Status: accepted
 - Context: Production `/api/races` warm-origin TTFB stayed ~1s and responses set avoidable Auth.js cookies despite being public.

--- a/src/app/api/cron/ingest-results/route.ts
+++ b/src/app/api/cron/ingest-results/route.ts
@@ -15,9 +15,9 @@
  */
 
 import { NextResponse } from 'next/server'
+import { stalePublicRaceCacheTags } from "@/lib/api/public-race-cache"
 import type { NextRequest } from 'next/server'
 import { validateCronSecret } from '@/lib/api/cron-auth'
-import { revalidatePublicRaceCache } from '@/lib/api/public-race-cache'
 import { db } from '@/lib/db/client'
 import { ingestResultsForRace, findRacesNeedingIngestion } from '@/lib/services/ingestion.service'
 import { computeAndStoreScoresForRace } from '@/lib/services/scoring.service'
@@ -190,12 +190,9 @@ export async function POST(req: NextRequest) {
   }
 
   console.log(
-    `[f10:cron:ingest] done in ${Date.now() - startedAt}ms processed=${results.length} errors=${results.filter((r) => r.error).length}`,
+    `[f10:cron:ingest] done in ${Date.now() - startedAt}ms processed=${results.length} errors=${results.filter((r) => r.error).length} staleTags=${stalePublicRaceCacheTags(mutatedRaceIds)}`,
   )
 
-  if (mutatedRaceIds.size > 0) {
-    revalidatePublicRaceCache(mutatedRaceIds)
-  }
 
   return NextResponse.json({ processed: results })
 }

--- a/src/app/api/cron/lock-picks/route.ts
+++ b/src/app/api/cron/lock-picks/route.ts
@@ -9,9 +9,9 @@
  */
 
 import { NextResponse } from "next/server"
+import { stalePublicRaceCacheTags } from "@/lib/api/public-race-cache"
 import type { NextRequest } from "next/server"
 import { validateCronSecret } from "@/lib/api/cron-auth"
-import { revalidatePublicRaceCache } from "@/lib/api/public-race-cache"
 import { db } from "@/lib/db/client"
 import { lockPicksForRace } from "@/lib/services/lock.service"
 
@@ -82,12 +82,9 @@ export async function POST(req: NextRequest) {
     lockedRaces++
   }
 
-  if (statusChangedRaceIds.size > 0) {
-    revalidatePublicRaceCache(statusChangedRaceIds)
-  }
 
   console.log(
-    `[f10:cron:lock] done in ${Date.now() - startedAt}ms lockedRaces=${lockedRaces} totalPicksLocked=${totalPicksLocked}`,
+    `[f10:cron:lock] done in ${Date.now() - startedAt}ms lockedRaces=${lockedRaces} totalPicksLocked=${totalPicksLocked} staleTags=${stalePublicRaceCacheTags(statusChangedRaceIds)}`,
   )
 
   return NextResponse.json({ lockedRaces, totalPicksLocked })

--- a/src/app/api/cron/sync-entries/route.ts
+++ b/src/app/api/cron/sync-entries/route.ts
@@ -12,9 +12,9 @@
  */
 
 import { NextResponse } from 'next/server'
+import { stalePublicRaceCacheTags } from "@/lib/api/public-race-cache"
 import type { NextRequest } from 'next/server'
 import { validateCronSecret } from '@/lib/api/cron-auth'
-import { revalidatePublicRaceCache } from '@/lib/api/public-race-cache'
 import { db } from '@/lib/db/client'
 import { createF1Provider } from '@/lib/f1/adapter'
 import { getRaceEntryRefreshSkipReason } from '../entry-refresh-guard'
@@ -179,9 +179,9 @@ export async function POST(req: NextRequest) {
     refreshedRaceIds.add(race.id)
   }
 
-  if (refreshedRaceIds.size > 0) {
-    revalidatePublicRaceCache(refreshedRaceIds)
-  }
+  console.log(
+    `[f10:cron:entries] done refreshed=${refreshed} skipped=${skipped.length} total=${upcomingRaces.length} staleTags=${stalePublicRaceCacheTags(refreshedRaceIds)}`,
+  )
 
   return NextResponse.json({ refreshed, skipped, total: upcomingRaces.length })
 }

--- a/src/app/api/cron/sync-schedule/route.ts
+++ b/src/app/api/cron/sync-schedule/route.ts
@@ -7,9 +7,9 @@
  */
 
 import { NextResponse } from "next/server"
+import { stalePublicRaceCacheTags } from "@/lib/api/public-race-cache"
 import type { NextRequest } from "next/server"
 import { validateCronSecret } from "@/lib/api/cron-auth"
-import { revalidatePublicRaceCache } from "@/lib/api/public-race-cache"
 import { db } from "@/lib/db/client"
 import { createF1Provider } from "@/lib/f1/adapter"
 import { fetchDriversForSessions } from "./driver-fetch"
@@ -354,7 +354,6 @@ export async function POST(req: NextRequest) {
 
   // Skip the remaining steps if no driver data was fetched
   if (sessionDrivers.every((sd) => sd.drivers.length === 0)) {
-    revalidatePublicRaceCache(mutatedRaceIds)
     return NextResponse.json({ synced, reconciled, year, driversSkipped: true })
   }
 
@@ -489,7 +488,9 @@ export async function POST(req: NextRequest) {
     ])
   }
 
-  revalidatePublicRaceCache(mutatedRaceIds)
+  console.log(
+    `[f10:cron:schedule] done synced=${synced} reconciled=${reconciled} year=${year} staleTags=${stalePublicRaceCacheTags(mutatedRaceIds)}`,
+  )
 
   return NextResponse.json({ synced, reconciled, year, entryRefreshSkipped })
 }

--- a/src/app/api/races/route-source.test.mjs
+++ b/src/app/api/races/route-source.test.mjs
@@ -72,15 +72,40 @@ test("middleware bypasses Auth.js before public race GETs can set cookies", () =
   )
 })
 
-test("race-data cron mutations revalidate public race cache tags", () => {
+test("public race responses are tagged with the header Vercel actually reads", () => {
+  // A bare `Cache-Tag` is the Cloudflare/Fastly convention and is ignored by
+  // Vercel, so tagging with it did nothing. `Vercel-Cache-Tag` is what makes
+  // `vercel cache invalidate --tag` and the edge-cache API able to purge these.
+  assert.match(cacheSource, /"Vercel-Cache-Tag": publicRaceCacheTagHeader\(raceId\)/)
+  assert.doesNotMatch(cacheSource, /"Cache-Tag":/)
+})
+
+test("public race caching claims no invalidation it cannot perform", () => {
+  // revalidateTag() only purges the Next.js Data Cache. These are plain dynamic
+  // route handlers whose caching is the CDN honouring s-maxage, and nothing
+  // registers a Data Cache entry — so the old revalidateTag calls were no-ops.
+  assert.doesNotMatch(cacheSource, /revalidateTag/)
+  assert.doesNotMatch(cacheSource, /from "next\/cache"/)
+
   for (const source of [
     syncScheduleSource,
     syncEntriesSource,
     ingestResultsSource,
     lockPicksSource,
   ]) {
-    assert.match(source, /revalidatePublicRaceCache/)
+    assert.doesNotMatch(source, /revalidatePublicRaceCache/)
   }
-  assert.match(cacheSource, /revalidateTag\(PUBLIC_RACES_TAG\)/)
-  assert.match(cacheSource, /revalidateTag\(publicRaceTag\(raceId\)\)/)
+})
+
+test("race-data crons log the cache tags their mutations made stale", () => {
+  // Purging is manual, so the cron output has to name what to purge.
+  for (const source of [
+    syncScheduleSource,
+    syncEntriesSource,
+    ingestResultsSource,
+    lockPicksSource,
+  ]) {
+    assert.match(source, /staleTags=\$\{stalePublicRaceCacheTags\(/)
+  }
+  assert.match(cacheSource, /export function stalePublicRaceCacheTags/)
 })

--- a/src/lib/api/public-race-cache.ts
+++ b/src/lib/api/public-race-cache.ts
@@ -1,4 +1,3 @@
-import { revalidateTag } from "next/cache"
 import type { RaceSummary } from "@/types/domain"
 
 export const PUBLIC_RACES_TAG = "public-races"
@@ -33,6 +32,20 @@ export function publicRaceCacheTagHeader(raceId?: string): string {
   return raceId ? `${PUBLIC_RACES_TAG}, ${publicRaceTag(raceId)}` : PUBLIC_RACES_TAG
 }
 
+/**
+ * Tags whose cached responses a cron run has just made stale, for logging.
+ *
+ * Public race caching is TTL-only (see `raceDetailCacheControl`), so nothing
+ * purges automatically. Logging the tags means an operator reading cron output
+ * knows exactly what to pass to `vercel cache invalidate --tag` if they need
+ * the change visible before the TTL expires.
+ */
+export function stalePublicRaceCacheTags(raceIds: Iterable<string>): string {
+  const ids = Array.from(new Set(raceIds))
+  if (ids.length === 0) return ""
+  return [PUBLIC_RACES_TAG, ...ids.map(publicRaceTag)].join(",")
+}
+
 export function serverTiming(
   entries: Array<{ name: string; durationMs?: number; description?: string }>,
 ): string {
@@ -59,14 +72,12 @@ export function publicRaceHeaders({
 }): HeadersInit {
   return {
     "Cache-Control": cacheControl,
-    "Cache-Tag": publicRaceCacheTagHeader(raceId),
+    // Vercel reads `Vercel-Cache-Tag`; a bare `Cache-Tag` is the Cloudflare/
+    // Fastly convention and is ignored here. Tagging makes these responses
+    // purgeable on demand:
+    //   vercel cache invalidate --tag public-race:<raceId>
+    // or POST /v1/edge-cache/invalidate-by-tags.
+    "Vercel-Cache-Tag": publicRaceCacheTagHeader(raceId),
     "Server-Timing": timing,
-  }
-}
-
-export function revalidatePublicRaceCache(raceIds: Iterable<string> = []): void {
-  revalidateTag(PUBLIC_RACES_TAG)
-  for (const raceId of Array.from(new Set(raceIds))) {
-    revalidateTag(publicRaceTag(raceId))
   }
 }


### PR DESCRIPTION
The tagged-invalidation half of #361 could not work, in two independent ways. This makes the code say what it actually does.

## Two independent breakages

**1. `revalidateTag()` had nothing to purge.** It only invalidates the Next.js Data Cache. Nothing in `src/` registers an entry:

```bash
grep -rn "unstable_cache\|use cache\|cacheTag" src/    # no matches
```

`/api/races` and `/api/races/[id]` are plain dynamic route handlers — their caching is entirely the CDN honouring `s-maxage`. So `revalidatePublicRaceCache()` was a no-op in all four crons.

**2. The tag header was the wrong one.** Responses carried `Cache-Tag`, which is the Cloudflare/Fastly convention. Vercel reads **`Vercel-Cache-Tag`** ([docs](https://vercel.com/docs/cdn-cache/purge)), so the tags were inert as well.

Net effect: caching was already TTL-only, but the code read as though targeted invalidation worked.

## The choice

Making purge genuinely automatic needs a Vercel API token in the cron environment (`POST /v1/edge-cache/invalidate-by-tags`). That is real infrastructure for marginal benefit, because the TTLs already bound staleness tightly — a status transition is bounded by the *previous* status's TTL, so LIVE → COMPLETED surfaces in ~15s and the list in ~60s.

So: keep the small mechanism that works, and make it honest.

- Remove `revalidatePublicRaceCache()` and its four cron call sites, plus the now-unused `next/cache` import.
- Rename the header to `Vercel-Cache-Tag`, which makes the tags genuinely purgeable on demand via `vercel cache invalidate --tag public-race:<raceId>`.
- Crons log `staleTags=` naming exactly which tags a run invalidated, so an operator can purge deliberately instead of guessing. This also keeps the raceId sets meaningful rather than write-only.

If automatic purge is wanted later, the tags are now correct — only the trigger would be missing.

## Test Plan

- [x] Tests rewritten to assert the *absence* of invalidation that cannot work, plus the correct header and the new logging: `route-source.test.mjs` 8/8
- [x] `npm run test:routes` 96/96, `test:auth` 17/17, `test:services` 32/32, `test:ios` 93/93, plus db/components/pages/utils/scoring/scripts:static — all pass
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run build` succeeds
- [x] Decision recorded in `ai/docs/decisions.md`

Header behaviour verified against Vercel's own docs rather than assumed.

Closes #392

— gib