### PR TITLE
Fix iOS build: add missing return in APIEndpoint.submitPick

### DIFF
--- a/ios/FXRacing/Core/Networking/APIEndpoint.swift
+++ b/ios/FXRacing/Core/Networking/APIEndpoint.swift
@@ -82,7 +82,7 @@ extension APIEndpoint {
         baseVersion: String? = nil
     ) -> APIEndpoint {
         let headers = baseVersion.map { ["If-Match": "\"\($0)\""] } ?? [:]
-        APIEndpoint(
+        return APIEndpoint(
             method: "POST",
             path: "/api/picks",
             bodyData: jsonBody([


### PR DESCRIPTION
The iOS app has not compiled on `main` since #385.

```
ios/FXRacing/Core/Networking/APIEndpoint.swift:85:9: error: missing return in
static method expected to return `APIEndpoint`
** BUILD FAILED **
```

## Cause

Swift applies the implicit single-expression return only when the body *is* a single expression. #385 added a `let headers = ...` line before the `APIEndpoint(...)` call, making the body two statements — so the expression became a discarded value and the function returned nothing.

One word fixes it.

## Why CI missed it

`.github/workflows/verify.yml` runs tsc, lint, the `npm run test:*` suites and `next build`. There is **no `xcodebuild` step**. The `ios/*.test.mjs` suites are Node source-contract tests that regex over Swift source; they never compile it. A green badge currently says nothing about whether the iOS app builds.

Worth a follow-up decision: add a native build step to CI, or document a pre-release native build gate. Raised in #395; not included here to keep this fix minimal.

## Test Plan

- [x] `xcodebuild -configuration Release` fails on clean `origin/main` (`2b13252`) with the error above
- [x] Same command succeeds with this change
- [x] `xcodegen generate` produces no project drift — the diff is one word
- [x] `npm run test:ios` unaffected

Found while verifying the 1.8.0 release branch. The same fix is also present in #373; whichever merges second will drop the duplicate hunk.

Closes #395

— gib