### PR TITLE
Make ranking rows actually open the player profile

### DIFF
--- a/ios/FXRacing/Features/Rankings/LeaderboardView.swift
+++ b/ios/FXRacing/Features/Rankings/LeaderboardView.swift
@@ -252,14 +252,22 @@ struct LeaderboardView: View {
             Section {
                 ForEach(vm.rows) { row in
                     let isCurrent = row.userId == currentUserId
-                    Button {
-                        selectedPlayer = SelectedPlayer(id: row.userId)
-                    } label: {
-                        LeaderboardRowView(row: row, isCurrentUser: isCurrent)
-                    }
-                    .buttonStyle(.plain)
-                    .contentShape(Rectangle())
-                    .accessibilityIdentifier("ranking-row-\(row.userId)")
+                    // A `Button` with `.buttonStyle(.plain)` wrapping this
+                    // custom label did not deliver taps inside the List — the
+                    // action never ran, so the profile sheet never opened.
+                    // (Plain-text buttons elsewhere in the same List work, and
+                    // the sheet itself works, so it was specific to this
+                    // combination.) A tap gesture on the row content is
+                    // reliable; the button trait keeps the row exposed as a
+                    // button to VoiceOver and UI tests.
+                    LeaderboardRowView(row: row, isCurrentUser: isCurrent)
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            selectedPlayer = SelectedPlayer(id: row.userId)
+                        }
+                        .accessibilityElement(children: .combine)
+                        .accessibilityAddTraits(.isButton)
+                        .accessibilityIdentifier("ranking-row-\(row.userId)")
                 }
             }
 


### PR DESCRIPTION
Tapping any row on the Rankings leaderboard did nothing — the profile sheet never presented. Present on `main`, so it has been shipping broken.

## Diagnosis

The cause is the **row**, not the sheet.

`LeaderboardView` wrapped the custom `LeaderboardRowView` label in a `Button` with `.buttonStyle(.plain)`. Inside this `List` that combination did not deliver taps — the action never ran, so `selectedPlayer` was never set.

Established by elimination rather than assumption:

- The element dump after a row tap shows **no sheet content at all** — only the main shell. So nothing presented.
- The `Sign In` button in the *same* `List`, driving the *same* view's sheet, presents correctly. So both the `List` and the sheet mechanism work.
- Therefore only the row's own tap delivery was broken.

I first blamed the three stacked `.sheet` modifiers on this view and consolidated them into one. **That did not fix it**, so I reverted it rather than leave an unrelated refactor in the diff. The three-sheet arrangement is fragile but demonstrably works here.

## Fix

Replace the `Button` with a tap gesture on the row content, keeping `.isButton` so VoiceOver and UI tests still see a button:

```swift
LeaderboardRowView(row: row, isCurrentUser: isCurrent)
    .contentShape(Rectangle())
    .onTapGesture { selectedPlayer = SelectedPlayer(id: row.userId) }
    .accessibilityElement(children: .combine)
    .accessibilityAddTraits(.isButton)
    .accessibilityIdentifier("ranking-row-\(row.userId)")
```

## Test Plan

- [x] `testRankingRowOpensAndDismissesPlayerProfileSheet` — was failing reproducibly (3 runs), now passes
- [x] Full `MainShellUITests` slice — 11/11 pass, `** TEST SUCCEEDED **`
- [x] Release `xcodebuild` succeeds
- [x] Manually verified on a Release build against production: tapping `max` opens the profile sheet with season score, the private-picks notice, and a working Done button

Found while running the #368 simulator verification. Depends on #396 for the app to compile at all.

Closes #394

— gib