### PR TITLE
Run functions in lhr1, co-located with the database

### DIFF
--- a/ai/docs/decisions.md
+++ b/ai/docs/decisions.md
@@ -20,6 +20,15 @@ Do not log temporary debugging notes here.
 ## Entries
 
 
+### 2026-07-26 — Vercel Functions run in lhr1, co-located with the database
+- Status: accepted
+- Context: #398. A cache miss on the public race APIs cost 1.5-1.9s. `Server-Timing` split the phases and showed a single primary-key `findUnique` taking **393 ms** (`db.race;dur=393.0`) with four concurrent related queries at 941 ms — two orders of magnitude above a warm indexed lookup, and not a request waterfall since the route already parallelises. The cause was geography: `x-vercel-id` showed functions executing in `iad1` (Washington DC) while the Supabase project is in **eu-west-2 (London)**. Every query crossed the Atlantic, and a TLS + auth handshake is several round trips on top.
+- Decision: pin `"regions": ["lhr1"]` in `vercel.json`. lhr1 is Vercel's London region, the same side of the ocean as the database.
+- Reason: co-locating compute with the database removes the transatlantic hop from every query. Requests make several DB round trips each, so the saving multiplies; the cost is one extra user-to-function hop, paid once.
+- Tradeoffs: users far from London see slightly higher latency on origin requests. This is heavily outweighed because the public race APIs are CDN-cached with a measured 97.5-100% hit rate — most requests are served from the edge nearest the user and never reach lhr1 at all. Only cache misses and authenticated routes pay the hop. The alternative, moving the database to us-east-1, is a data migration with downtime and was not justified.
+- Affected areas: `vercel.json`, guarded by `scripts/vercel-region.test.mjs`.
+- Follow-up: re-measure origin p95 after deploy; #361's target was ≤750 ms.
+
 ### 2026-07-26 — Public race caching is TTL-only; tags are for manual purge
 - Status: accepted
 - Context: #361 shipped CDN caching plus what looked like targeted invalidation: responses carried a `Cache-Tag` header and the four race-mutating crons called `revalidatePublicRaceCache()`, which called `revalidateTag()`. Both halves were inert. `revalidateTag()` only purges the Next.js Data Cache, and `git grep` finds no `unstable_cache` / `'use cache'` / `cacheTag` anywhere in `src/` — these are plain dynamic route handlers whose caching is purely the CDN honouring `s-maxage`, so there was no registered entry to purge. Separately, Vercel reads `Vercel-Cache-Tag`; a bare `Cache-Tag` is the Cloudflare/Fastly convention and is ignored. The code therefore read as if invalidation worked when nothing could purge anything (#392).

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:pages": "node --test src/app/page.test.mjs src/app/landing-routes.test.mjs src/app/privacy/page.test.mjs src/app/support/page.test.mjs",
     "test:utils": "node --test src/lib/observability/client-errors.test.mjs",
     "test:scoring": "node --test src/lib/scoring/formula.test.mjs",
-    "test:scripts:static": "node --test scripts/app-store-screenshots.test.mjs scripts/backfill-locked-snapshots.test.mjs scripts/cleanup-orphaned-races.test.mjs scripts/db-entrypoint.test.mjs scripts/find-cheated-picks.test.mjs scripts/install-pickset-triggers.test.mjs scripts/maintenance-season-guards.test.mjs scripts/tsconfig-prisma-coverage.test.mjs scripts/vercel-cli-doc.test.mjs",
+    "test:scripts:static": "node --test scripts/app-store-screenshots.test.mjs scripts/backfill-locked-snapshots.test.mjs scripts/cleanup-orphaned-races.test.mjs scripts/db-entrypoint.test.mjs scripts/find-cheated-picks.test.mjs scripts/install-pickset-triggers.test.mjs scripts/maintenance-season-guards.test.mjs scripts/tsconfig-prisma-coverage.test.mjs scripts/vercel-cli-doc.test.mjs scripts/vercel-region.test.mjs",
     "test:services": "node --test src/lib/services/pick.service.test.mjs src/lib/services/race.service.test.mjs src/lib/services/race-summary.mapper.test.mjs src/lib/services/driver-season-stats.test.mjs src/lib/services/user.service.test.mjs src/lib/services/leaderboard-rank.test.mjs src/lib/services/leaderboard.service.test.mjs src/lib/services/friendship.service.test.mjs src/lib/services/qualifying.service.test.mjs src/lib/services/scoring-pick-resolution.test.mjs src/lib/services/scoring.service.test.mjs src/lib/f1/providers/openf1.test.mjs",
     "lint": "next lint",
     "db:push": "prisma db push",

--- a/scripts/vercel-region.test.mjs
+++ b/scripts/vercel-region.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { readFile } from "node:fs/promises"
+
+const config = JSON.parse(
+  await readFile(new URL("../vercel.json", import.meta.url), "utf8"),
+)
+
+// The Supabase database lives in eu-west-2 (London). Functions previously ran
+// in the Vercel default (iad1, Washington DC), so every query crossed the
+// Atlantic: a primary-key findUnique measured 393ms in production. lhr1 is
+// Vercel's London region — the same side of the ocean as the database.
+test("functions run in the same region as the database", () => {
+  assert.deepEqual(config.regions, ["lhr1"])
+})
+
+test("cron routes keep their extended duration", () => {
+  assert.equal(config.functions["src/app/api/cron/**"].maxDuration, 60)
+})

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "regions": ["lhr1"],
   "functions": {
     "src/app/api/cron/**": {
       "maxDuration": 60


### PR DESCRIPTION
A cache miss on the public race APIs cost 1.5-1.9s. The cause turned out to be geography, not code.

## Evidence

Splitting `Server-Timing` into phases:

```
db.race;dur=393.0      <- ONE findUnique on the primary key
db.related;dur=941.0   <- four queries, already concurrent
```

393 ms for a primary-key lookup is two orders of magnitude above a warm indexed query, and it is not a request waterfall — the route already runs its related reads in a single `Promise.all`.

Then the two locations:

- `x-vercel-id: yul1::iad1::…` — functions execute in **iad1** (Washington DC)
- Supabase dashboard — the project is in **eu-west-2 (London)**

So every query crossed the Atlantic, and a TLS + auth handshake is several round trips on top of the base RTT. That fully accounts for the magnitude.

## Change

```json
"regions": ["lhr1"]
```

`lhr1` is Vercel's London region — the same side of the ocean as the database.

## Why this direction

Each request makes several DB round trips, so co-locating multiplies the saving. The cost is one extra user-to-function hop, paid once.

That cost is small here specifically because the public race APIs are CDN-cached with a **measured 97.5-100% hit rate** — most requests are served from the edge nearest the user and never reach `lhr1`. Only cache misses and authenticated routes pay the hop.

The alternative — moving the database to `us-east-1` — reaches the same end state via a data migration with downtime, so it was not justified.

## Test Plan

- [x] `scripts/vercel-region.test.mjs` pins `regions` to `["lhr1"]` and asserts the cron `maxDuration` is preserved; wired into `test:scripts:static` (21/21)
- [x] `npx tsc --noEmit` clean, `npm run lint` clean
- [x] Decision recorded in `ai/docs/decisions.md` with the measurements
- [ ] Re-measure origin p95 after deploy — #361 targeted ≤750 ms

Region confirmed against Vercel's own docs for the `vercel.json` `regions` key rather than assumed.

Closes #398

— gib