### PR TITLE
Fix the two performance scenarios broken by the deck redesign

### DIFF
--- a/ios/FXRacing/Features/Races/RaceDeckView.swift
+++ b/ios/FXRacing/Features/Races/RaceDeckView.swift
@@ -294,15 +294,11 @@ struct RaceDeckView: View {
                 if let race = selectedRace,
                    let detail = scopedSelectedDetail,
                    detail.race.id == race.id {
-                    RaceContextView(
-                        section: section,
-                        race: race,
-                        detail: detail
-                    )
-                    .padding(.horizontal, 18)
-                    .transition(.opacity.combined(with: .move(edge: .bottom)))
-
                     #if FX_PERF_HARNESS
+                    // Must sit *above* RaceContextView. This is a LazyVStack,
+                    // so anything below the tall season-form table is not
+                    // instantiated and the marker never reaches the
+                    // accessibility tree for the harness to find.
                     if !detail.entrants.isEmpty {
                         Color.clear
                             .frame(width: 1, height: 1)
@@ -312,6 +308,14 @@ struct RaceDeckView: View {
                             .allowsHitTesting(false)
                     }
                     #endif
+
+                    RaceContextView(
+                        section: section,
+                        race: race,
+                        detail: detail
+                    )
+                    .padding(.horizontal, 18)
+                    .transition(.opacity.combined(with: .move(edge: .bottom)))
                 }
             }
             .padding(.vertical, 4)

--- a/ios/FXRacing/Features/Races/RacePickStatusRail.swift
+++ b/ios/FXRacing/Features/Races/RacePickStatusRail.swift
@@ -203,6 +203,10 @@ struct RacePickStatusRail: View {
         .accessibilityLabel(status.title)
         .accessibilityValue(accessibilityValue)
         .accessibilityHint(accessibilityHint)
+        // `children: .ignore` collapses the rail into a single element, so the
+        // inner Text views are not exposed as static texts. UI tests need a
+        // stable hook to read the pick state from.
+        .accessibilityIdentifier("race-pick-status")
     }
 
     private var content: some View {

--- a/ios/FXRacingUITests/FXRacingPerformanceTests.swift
+++ b/ios/FXRacingUITests/FXRacingPerformanceTests.swift
@@ -266,7 +266,7 @@ final class FXRacingPerformanceTests: XCTestCase {
             let finalDriver = try self.prepareTwoPicks(in: app)
             let start = ContinuousClock.now
             finalDriver.tap()
-            guard app.staticTexts["Saved on this iPhone"].waitForExistence(timeout: 10) else {
+            guard self.waitUntilSaved(in: app) else {
                 throw HarnessFailure.notReady("Saved state")
             }
             return self.seconds(start.duration(to: .now))
@@ -299,7 +299,7 @@ final class FXRacingPerformanceTests: XCTestCase {
                 app.terminate()
                 return
             }
-            XCTAssertTrue(app.staticTexts["Saved on this iPhone"].waitForExistence(timeout: 10))
+            XCTAssertTrue(waitUntilSaved(in: app))
             app.terminate()
         }
     }
@@ -447,6 +447,27 @@ final class FXRacingPerformanceTests: XCTestCase {
             RunLoop.current.run(until: Date().addingTimeInterval(0.01))
         } while ContinuousClock.now < deadline
         return condition()
+    }
+
+    /// Titles the pick status rail shows once a pick is persisted locally.
+    /// Which one appears depends on auth and sync state — "Picks saved" when
+    /// signed in and settled, "Saved on this iPhone" for a guest or while a
+    /// sync is still pending. Both mean the local write completed, which is
+    /// what these scenarios measure.
+    private static let savedStatusTitles: Set<String> = [
+        "Picks saved",
+        "Saved on this iPhone",
+    ]
+
+    /// The rail applies `accessibilityElement(children: .ignore)`, so its text
+    /// is the element's label rather than a static text. Match by identifier
+    /// and read the label.
+    @MainActor
+    private func waitUntilSaved(in app: XCUIApplication) -> Bool {
+        let rail = element("race-pick-status", in: app)
+        return waitUntil {
+            rail.exists && Self.savedStatusTitles.contains(rail.label)
+        }
     }
 
     @MainActor

--- a/ios/driver-picker-sheet.test.mjs
+++ b/ios/driver-picker-sheet.test.mjs
@@ -81,7 +81,21 @@ test("local-save performance starts immediately before final selection", () => {
   )?.[0] ?? "";
   assert.match(diagnostic, /let start = ContinuousClock\.now\s*finalDriver\.tap\(\)/);
   assert.match(performanceUITestSource, /prepareTwoPicks/);
-  assert.doesNotMatch(performanceUITestSource, /save-picks-|Save picks|Picks saved/);
+  // Picks autosave, so the harness must never drive an explicit save control.
+  // "Picks saved" is allowed: it is one of the status-rail titles the harness
+  // waits on to observe that the autosave landed, not a button it taps.
+  assert.doesNotMatch(performanceUITestSource, /save-picks-|Save picks|savePicksButton/);
+});
+
+test("the local-save harness waits on the status rail, not a fixed string", () => {
+  // The rail collapses its children, so its text is the element label rather
+  // than a static text, and the title varies with auth and sync state.
+  assert.match(performanceUITestSource, /element\("race-pick-status", in: app\)/);
+  assert.match(performanceUITestSource, /savedStatusTitles\.contains\(rail\.label\)/);
+  assert.doesNotMatch(
+    performanceUITestSource,
+    /staticTexts\["Saved on this iPhone"\]/,
+  );
 });
 
 test("pick rows stay visibly unavailable until driver data is ready", () => {


### PR DESCRIPTION
`race-swipe` and `local-save` never reached their measurement phase, leaving the **race-selection** and **local-save** p95 gates unverifiable. Neither was a performance regression — both were harness assertions the redesign invalidated.

## race-swipe

The `FX_PERF_HARNESS` readiness marker sat **after** `RaceContextView` inside a `LazyVStack`. The redesign made that view tall (the season-form table), so the marker fell outside the lazy render window, was never instantiated, and never reached the accessibility tree.

I got this wrong twice before getting it right, so I stopped guessing and wrote a throwaway diagnostic that dumped the tree. That showed the marker was missing **before the swipe too** — which reframed it from "detail is not loading" to "the view is never built".

After moving it above `RaceContextView`:

```
before swipe: spa marker exists=true
after swipe:  spa=false, monza=true
```

Both earlier attempts were reverted rather than left in as unrelated edits: the detail *does* load after a swipe, and forcing identity with `.id()` changed nothing.

## local-save

Two causes stacked.

1. `RacePickStatusRail` applies `accessibilityElement(children: .ignore)`, collapsing the rail into one element. Its text is the element's **label**, never a static text, so `staticTexts["Saved on this iPhone"]` could not resolve.
2. Underneath that, the copy also changed. Instrumenting the helper showed it directly:

```
DIAG rail.exists=true          <- the new identifier resolves
DIAG rail.label=Picks saved    <- but the string moved on
```

The rail reads `"Picks saved"` when signed in and settled, `"Saved on this iPhone"` for a guest or pending sync. The harness now matches by identifier and accepts either saved title, so it is not pinned to one string the next copy edit would break.

## Guard relaxation

`driver-picker-sheet.test.mjs` banned the literal `Picks saved` anywhere in the harness. That guard exists to stop the harness driving an explicit save control now that picks autosave — but `"Picks saved"` is a status title to *observe*, not a button to tap. Narrowed to `save-picks-|Save picks|savePicksButton`, and added a test pinning the new rail-based wait so it cannot silently regress.

## Results

| Gate | p95 | Threshold | |
|---|---|---|---|
| race-selection-ready | 0.255s | 0.600s | PASS |
| save-completion | 0.027s | 0.200s | PASS |

**All seven enforced gates are now verified.** The other five were already passing: launch-to-shell 0.344s, cached-publication 0.024s, driver-picker-preparation 0.002s, driver-picker-presentation 0.130s, schedule-presentation 0.096s.

## Test Plan

- [x] `scripts/ios-performance --scenario race-swipe` — PASS
- [x] `scripts/ios-performance --scenario local-save` — PASS
- [x] `npm run test:ios` 122/122
- [x] `npx tsc --noEmit` clean, `npm run lint` clean
- [x] Release `xcodebuild` succeeds — the marker move is inside `#if FX_PERF_HARNESS` and cannot ship

Note: the marker move affects only harness-conditional code. The one change that reaches Release is an `accessibilityIdentifier` on the status rail, which is inert.

Closes #401

— gib