### PR TITLE
Stop the pick status rail being clipped by the race card

### DIFF
--- a/ios/FXRacing/Features/Races/UpcomingCardLayoutMetrics.swift
+++ b/ios/FXRacing/Features/Races/UpcomingCardLayoutMetrics.swift
@@ -15,15 +15,21 @@ enum UpcomingCardLayoutMetrics {
     ) -> CGFloat {
         _ = contentState
 
+        // Measured from the uncapped card, then rounded up with a small margin.
+        // Natural content heights were S 443, M 447, L 451, XL 461, XXL 470,
+        // XXXL 480 — the previous values clipped the pick status rail at every
+        // non-accessibility size. Keep these at or above the measurements: the
+        // card hard-caps maxHeight to keep pager geometry stable, so anything
+        // short is cut off rather than scrolled.
         return switch dynamicTypeSize {
         case .xSmall, .small, .medium, .large:
-            412
+            458
         case .xLarge:
-            430
-        case .xxLarge:
-            448
-        case .xxxLarge:
             468
+        case .xxLarge:
+            478
+        case .xxxLarge:
+            488
         case .accessibility1:
             760
         case .accessibility2:

--- a/ios/FXRacingTests/Features/Races/UpcomingCardLayoutMetricsTests.swift
+++ b/ios/FXRacingTests/Features/Races/UpcomingCardLayoutMetricsTests.swift
@@ -30,8 +30,8 @@ final class UpcomingCardLayoutMetricsTests: XCTestCase {
             )
             XCTAssertGreaterThanOrEqual(
                 height,
-                412,
-                "Card height should preserve the current visual floor at \(size)"
+                458,
+                "Card height should preserve the measured visual floor (rail must not clip) at \(size)"
             )
             previousHeight = height
         }
@@ -54,7 +54,7 @@ final class UpcomingCardLayoutMetricsTests: XCTestCase {
     func testNormalSizeCardGeometryRemainsTask6Stable() {
         XCTAssertEqual(
             UpcomingCardLayoutMetrics.cardHeight(for: .large),
-            412,
+            458,
             accuracy: 0.001
         )
     }


### PR DESCRIPTION
The status row — "Picks saved", "Choose 3 more" — was cut off by the card's bottom edge, with the status icon sliced in half. Reported from a Release build on a physical iPhone 15 Pro Max, and reproducible in the simulator at default Dynamic Type in **both** the empty and saved states.

## Cause

`UpcomingRaceCard.swift:49-52` hard-caps `maxHeight` at non-accessibility sizes so every card in the pager is the same height. That constraint is correct — it stops the deck jumping as you swipe — but the constants were smaller than the content the redesign added, so the overflow was clipped rather than shown.

Accessibility sizes already pass `nil` for `maxHeight` and grow, so they were never affected. This was default-size-only.

## Measured, not guessed

I temporarily uncapped the card and had it report its laid-out height per size class:

| | S | M | L | XL | XXL | XXXL |
|---|---|---|---|---|---|---|
| natural | 443 | 447 | 451 | 461 | 470 | 480 |
| constant was | 412 | 412 | 412 | 430 | 448 | 468 |
| **now** | **458** | **458** | **458** | **468** | **478** | **488** |

Roughly **39pt short** at default. New values sit just above each measurement — enough margin for rounding, not enough to leave visible dead space.

The monotonic-height unit test asserted a `412` floor; that moves to `458`, which is now the measured minimum rather than an inherited number.

## Verified

Simulator, default Dynamic Type, both states:

- **Empty:** "Choose 3 more" *and* its "Finish before qualifying for 2×" detail line fully visible, circle icon complete
- **Saved:** "Picks saved" with a whole checkmark, clearance below

## Test Plan

- [x] `npm run test:ios` 122/122
- [x] `UpcomingCardLayoutMetricsTests` floor updated to the measured value; monotonic + state-stability assertions still hold
- [x] Release `xcodebuild` succeeds
- [x] Visually confirmed in the empty and saved states

Not addressed here: the picker's auto-advance is hard to notice (#405). Separate concern, separate PR.

Closes #404

— gib