### PR TITLE
Give the race card a real edge in light mode

### DIFF
--- a/ios/FXRacing/DesignSystem/FXTheme.swift
+++ b/ios/FXRacing/DesignSystem/FXTheme.swift
@@ -45,6 +45,21 @@ enum FXTheme {
                 : .white
         })
 
+        /// Card edge that stays visible in both modes.
+        ///
+        /// A hardcoded white stroke disappears on a light card, which is what
+        /// made the race card lose its edge in light mode and left the fill
+        /// gradient reading as a stray line.
+        static func cardBorder(isSelected: Bool) -> Color {
+            Color(uiColor: UIColor { traits in
+                let isDark = traits.userInterfaceStyle == .dark
+                let alpha: CGFloat = isSelected ? 0.16 : 0.09
+                return isDark
+                    ? UIColor(white: 1, alpha: alpha)
+                    : UIColor(white: 0, alpha: alpha)
+            })
+        }
+
         static let textPrimary   = Color.primary
         static let textSecondary = Color.secondary
         static let textTertiary  = Color(uiColor: .tertiaryLabel)

--- a/ios/FXRacing/DesignSystem/FXTheme.swift
+++ b/ios/FXRacing/DesignSystem/FXTheme.swift
@@ -14,8 +14,12 @@ private struct FXCardSurfaceModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .background(FXTheme.Colors.surface)
-            .cornerRadius(radius)
+            .background(FXTheme.Colors.surfaceElevated)
+            .clipShape(RoundedRectangle(cornerRadius: radius, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: radius, style: .continuous)
+                    .strokeBorder(FXTheme.Colors.cardBorder(isSelected: false), lineWidth: 1)
+            }
     }
 }
 

--- a/ios/FXRacing/Features/Home/MainShellView.swift
+++ b/ios/FXRacing/Features/Home/MainShellView.swift
@@ -40,7 +40,7 @@ struct MainShellView: View {
 
             selectedContent
         }
-        .background(Color(uiColor: .systemBackground))
+        .background(Color(uiColor: .systemGroupedBackground))
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("main-shell")
         .onAppear {

--- a/ios/FXRacing/Features/Races/PastRaceCard.swift
+++ b/ios/FXRacing/Features/Races/PastRaceCard.swift
@@ -24,7 +24,7 @@ struct PastRaceCard: View {
         .frame(maxWidth: .infinity, minHeight: 344, alignment: .topLeading)
         .background(
             LinearGradient(
-                colors: [FXTheme.Colors.surfaceElevated, FXTheme.Colors.surface],
+                colors: [FXTheme.Colors.surfaceElevated, FXTheme.Colors.surfaceElevated],
                 startPoint: .topLeading,
                 endPoint: .bottomTrailing
             )
@@ -32,7 +32,7 @@ struct PastRaceCard: View {
         .clipShape(RoundedRectangle(cornerRadius: FXTheme.Radius.xl, style: .continuous))
         .overlay {
             RoundedRectangle(cornerRadius: FXTheme.Radius.xl, style: .continuous)
-                .strokeBorder(.white.opacity(isSelected ? 0.14 : 0.07), lineWidth: 1)
+                .strokeBorder(FXTheme.Colors.cardBorder(isSelected: isSelected), lineWidth: 1)
         }
         .shadow(color: .black.opacity(isSelected ? 0.16 : 0.08), radius: 18, y: 8)
         .accessibilityElement(children: .contain)

--- a/ios/FXRacing/Features/Races/UpcomingRaceCard.swift
+++ b/ios/FXRacing/Features/Races/UpcomingRaceCard.swift
@@ -55,7 +55,7 @@ struct UpcomingRaceCard: View {
         .clipShape(RoundedRectangle(cornerRadius: FXTheme.Radius.xl, style: .continuous))
         .overlay {
             RoundedRectangle(cornerRadius: FXTheme.Radius.xl, style: .continuous)
-                .strokeBorder(.white.opacity(isSelected ? 0.14 : 0.07), lineWidth: 1)
+                .strokeBorder(FXTheme.Colors.cardBorder(isSelected: isSelected), lineWidth: 1)
         }
         .shadow(color: .black.opacity(isSelected ? 0.16 : 0.08), radius: 18, y: 8)
         .accessibilityElement(children: .contain)
@@ -208,14 +208,11 @@ struct UpcomingRaceCard: View {
         return "Starts in \(hours / 24)d \(hours % 24)h"
     }
 
+    /// Flat elevated surface rather than a gradient. In light mode the old
+    /// gradient ran pure white -> 0.97 against a white page, so its darker end
+    /// was the only visible boundary and read as a stray line. Separation now
+    /// comes from the page being a grouped background, plus a real border.
     private var cardBackground: some ShapeStyle {
-        LinearGradient(
-            colors: [
-                FXTheme.Colors.surfaceElevated,
-                FXTheme.Colors.surface,
-            ],
-            startPoint: .topLeading,
-            endPoint: .bottomTrailing
-        )
+        FXTheme.Colors.surfaceElevated
     }
 }


### PR DESCRIPTION
In light mode the race card showed what looked like a hard line at its top and bottom edges. Dark mode looked fine — which turned out to be the clue.

## Cause

Two things combined, both misbehaving only in light mode.

**The fill** was a diagonal gradient `surfaceElevated → surface`. In light mode that is **pure white → 0.97 grey**, sitting on a `systemBackground` page that is also white. The card barely separated from the page.

**The edge** that should have defined it was hardcoded white:

```swift
.strokeBorder(.white.opacity(isSelected ? 0.14 : 0.07), lineWidth: 1)
```

A white stroke on a white card is invisible. With no real edge, the only perceptible boundary was where the gradient darkened toward 0.97 — and that read as a stray line rather than a card.

Dark mode was fine because the same white stroke reads as a rim light, and 0.17 → 0.12 looks like intentional sheen.

## Change

- `FXTheme.Colors.cardBorder(isSelected:)` is mode-aware — white in dark, black in light — so the card has an edge in both.
- The card fill is flat `surfaceElevated`. Separation should come from the page and the border, not a gradient nobody asked to see.
- The shell background is `systemGroupedBackground`, so cards sit on grey in light and near-black in dark — the usual iOS grouped arrangement.

`PastRaceCard` carried the identical hardcoded white stroke and is fixed alongside it.

## Verified

Simulator, `gameplay` fixture, both appearances:

- **Light** — clean white card with a visible rounded edge on grey, no banding
- **Dark** — unchanged; still elevated with a soft rim, now on a properly black page

## Test Plan

- [x] `npm run test:ios` 126/126
- [x] `xcodebuild` succeeds
- [x] Visually confirmed in light and dark
- [x] Selected vs unselected emphasis preserved in both modes

Closes #410

— gib