### PR TITLE
Make status and warning colours survive light mode

### DIFF
--- a/ios/FXRacing/DesignSystem/ErrorBanner.swift
+++ b/ios/FXRacing/DesignSystem/ErrorBanner.swift
@@ -8,7 +8,7 @@ struct ErrorBanner: View {
     var body: some View {
         HStack(spacing: 10) {
             Image(systemName: "exclamationmark.triangle.fill")
-                .foregroundStyle(.yellow)
+                .foregroundStyle(FXTheme.Colors.warning)
                 .font(.subheadline)
             Text(message)
                 .font(.footnote)
@@ -28,7 +28,7 @@ struct ErrorBanner: View {
         .background(Color(uiColor: .secondarySystemBackground))
         .overlay(
             RoundedRectangle(cornerRadius: FXTheme.Radius.md)
-                .stroke(Color.yellow.opacity(0.4), lineWidth: 1)
+                .stroke(FXTheme.Colors.warning.opacity(0.5), lineWidth: 1)
         )
         .cornerRadius(FXTheme.Radius.md)
         .padding(.horizontal, FXTheme.Spacing.md)
@@ -67,7 +67,7 @@ struct RetryView: View {
                 }
                 .frame(width: 100, height: 40)
                 .background(FXTheme.Colors.accent)
-                .foregroundStyle(.black)
+                .foregroundStyle(FXTheme.Colors.onAccent)
                 .cornerRadius(FXTheme.Radius.md)
             }
             .disabled(isRetrying)

--- a/ios/FXRacing/DesignSystem/FXTheme.swift
+++ b/ios/FXRacing/DesignSystem/FXTheme.swift
@@ -31,7 +31,14 @@ enum FXTheme {
         /// Text color to use on top of accent-colored backgrounds.
         static let onAccent: Color = .white
         /// #C9A227 — gold, used for P10 exact hits.
-        static let gold   = Color(red: 0.79, green: 0.64, blue: 0.15)
+        /// Adaptive: the original #C9A227 is tuned for dark surfaces and only
+        /// reaches 2.4:1 on white, which is too weak for the small monospaced
+        /// score numerals it labels. Dark mode keeps the original value.
+        static let gold = Color(uiColor: UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.79, green: 0.64, blue: 0.15, alpha: 1)
+                : UIColor(red: 0.55, green: 0.42, blue: 0.02, alpha: 1)
+        })
         /// #ff453a — danger/DNF red.
         static let danger = Color(red: 1.00, green: 0.27, blue: 0.23)
 
@@ -47,6 +54,22 @@ enum FXTheme {
             traits.userInterfaceStyle == .dark
                 ? UIColor(white: 0.17, alpha: 1)
                 : .white
+        })
+
+        /// Status colours that hold contrast on BOTH a white and a black
+        /// surface. The system `.yellow` and `.green` are tuned for dark
+        /// backgrounds — on white they land near 1.3:1 and 1.9:1, so a status
+        /// dot painted with them simply disappears in light mode.
+        static let warning = Color(uiColor: UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 1.00, green: 0.84, blue: 0.20, alpha: 1)
+                : UIColor(red: 0.72, green: 0.52, blue: 0.00, alpha: 1)
+        })
+
+        static let success = Color(uiColor: UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.35, green: 0.85, blue: 0.42, alpha: 1)
+                : UIColor(red: 0.11, green: 0.48, blue: 0.18, alpha: 1)
         })
 
         /// Card edge that stays visible in both modes.

--- a/ios/FXRacing/Features/Auth/SignInPromptView.swift
+++ b/ios/FXRacing/Features/Auth/SignInPromptView.swift
@@ -55,8 +55,12 @@ struct SignInPromptView: View {
                     .overlay {
                         if vm.isLoading {
                             RoundedRectangle(cornerRadius: FXTheme.Radius.md)
-                                .fill(.black.opacity(0.35))
-                            ProgressView().tint(.white)
+                                .fill(
+                                    colorScheme == .dark
+                                        ? Color.white.opacity(0.45)
+                                        : Color.black.opacity(0.35)
+                                )
+                            ProgressView().tint(colorScheme == .dark ? .black : .white)
                         }
                     }
 

--- a/ios/FXRacing/Features/Auth/SignInView.swift
+++ b/ios/FXRacing/Features/Auth/SignInView.swift
@@ -54,8 +54,12 @@ struct SignInView: View {
                     .overlay {
                         if viewModel.isLoading {
                             RoundedRectangle(cornerRadius: FXTheme.Radius.md)
-                                .fill(.black.opacity(0.35))
-                            ProgressView().tint(.white)
+                                .fill(
+                                    colorScheme == .dark
+                                        ? Color.white.opacity(0.45)
+                                        : Color.black.opacity(0.35)
+                                )
+                            ProgressView().tint(colorScheme == .dark ? .black : .white)
                         }
                     }
 

--- a/ios/FXRacing/Features/Onboarding/UsernamePickerView.swift
+++ b/ios/FXRacing/Features/Onboarding/UsernamePickerView.swift
@@ -49,8 +49,14 @@ struct UsernamePickerView: View {
                                 }
                                 .padding(.horizontal, FXTheme.Spacing.md)
                                 .padding(.vertical, 14)
-                                .background(FXTheme.Colors.surface)
-                                .cornerRadius(FXTheme.Radius.md)
+                                .background(
+                                    RoundedRectangle(cornerRadius: FXTheme.Radius.md)
+                                        .fill(Color(uiColor: .secondarySystemBackground))
+                                )
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: FXTheme.Radius.md)
+                                        .stroke(Color(uiColor: .separator), lineWidth: 1)
+                                )
 
                             if let format = viewModel.formatError {
                                 Text(format)

--- a/ios/FXRacing/Features/Profile/FriendProfileView.swift
+++ b/ios/FXRacing/Features/Profile/FriendProfileView.swift
@@ -175,8 +175,8 @@ struct FriendProfileView: View {
     @ViewBuilder
     private func statusDot(_ status: String) -> some View {
         let color: Color = switch status {
-        case "exact": .green
-        case "correct", "partial": Color(red: 1, green: 0.8, blue: 0)
+        case "exact": FXTheme.Colors.success
+        case "correct", "partial": FXTheme.Colors.warning
         case "miss": .red
         default: .gray
         }

--- a/ios/FXRacing/Features/Profile/ProfileView.swift
+++ b/ios/FXRacing/Features/Profile/ProfileView.swift
@@ -172,8 +172,8 @@ struct ProfileView: View {
     @ViewBuilder
     private func statusDot(_ status: String) -> some View {
         let color: Color = switch status {
-        case "exact": .green
-        case "correct", "partial": Color(red: 1, green: 0.8, blue: 0)
+        case "exact": FXTheme.Colors.success
+        case "correct", "partial": FXTheme.Colors.warning
         case "miss": .red
         default: .gray
         }


### PR DESCRIPTION
Audit follow-up. After two light-mode bugs traced to the same cause, a sweep of `ios/FXRacing/` found the pattern is systemic:

```
.white          18 usages
.black          33
Color(red:…)     5
─────────────────────
trait-aware      2      ← only surface / surfaceElevated
```

The theme was built dark-first, so anything tuned against a dark surface silently fails on white. That is why every visual defect reported so far has been light-mode-only.

## Fixed — things that were invisible or illegible

**The warning banner was not a warning.** `ErrorBanner` used system `.yellow` for both the glyph and the border over `secondarySystemBackground` — about **1.3:1** in light. Icon and outline both vanished; it read as plain text.

**A partial hit looked like no pick at all.** The status dot used `#FFCC00` on white at ~**1.4:1**, so `correct`/`partial` was indistinguishable from an empty slot. `.green` in the same switch was only 1.9:1.

**The onboarding username field had no boundary** — 0.97 grey fill on a white sheet, no border, no `textFieldStyle`. Now uses the system field background plus a separator stroke. Highest practical cost of the set: it is an interactive target during first run.

**Retry button contrast** — `.black` on accent red (~4.0:1), bypassing the existing `onAccent` token.

**Sign-in spinner broke in dark** — the inverse direction from everything else. The Apple button is scheme-aware; the loading overlay was a fixed black scrim with a white spinner, so in dark a white spinner sat on a light scrim over a white button.

## Tokens

Adds adaptive `warning` and `success`. Makes `gold` adaptive — it keeps its exact dark value and gains a darker light variant, because it labels small monospaced score numerals that sat at 2.4:1.

Measured after:

| token | on white | on black |
|---|---|---|
| warning | **3.3:1** (was 1.5) | 13.3:1 |
| success | **5.4:1** | 10.3:1 |
| gold | **5.0:1** (was 2.4) | unchanged |

## Note on scope

`gold` is a brand colour, so changing it is a judgement call. Dark mode is byte-identical; only light darkens. Revert that hunk if you would rather keep the exact brand value everywhere and accept 2.4:1 on light.

## Test Plan

- [x] `npm run test:ios` 126/126
- [x] `xcodebuild` succeeds
- [x] Contrast ratios computed for every changed colour against both backgrounds
- [ ] Visual check on device in both modes

Not included: `.black` shadows (correct as-is) and `.white` on accent-red fills (correct, though they bypass `onAccent` — cosmetic consistency only).

Closes #413

— gib